### PR TITLE
Rename repository to `openslide-bin`

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -1,9 +1,9 @@
-# openslide-winbuild release process
+# openslide-bin release process
 
 - [ ] Update software versions, submit PR
 - [ ] Land PR
 - [ ] Create and push signed tag
-- [ ] Verify that CI creates a [GitHub release](https://github.com/openslide/openslide-winbuild/releases/) with artifacts
+- [ ] Verify that CI creates a [GitHub release](https://github.com/openslide/openslide-bin/releases/) with artifacts
 - [ ] Update website: `_data/releases.yaml`, maybe `_includes/news.md`
 - [ ] Possibly send mail to -announce and -users
 - [ ] Update `WINBUILD_RELEASE` in [OpenSlide Python CI](https://github.com/openslide/openslide-python/blob/main/.github/workflows/python.yml)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,13 +33,13 @@ on:
         description: Override OpenSlide Java with this openslide_java_repo ref
         required: false
         type: string
-      openslide_winbuild_repo:
-        description: Use openslide-winbuild from this repo
+      openslide_bin_repo:
+        description: Use openslide-bin from this repo
         required: false
         type: string
-        default: openslide/openslide-winbuild
-      openslide_winbuild_ref:
-        description: Use openslide-winbuild from this ref
+        default: openslide/openslide-bin
+      openslide_bin_ref:
+        description: Use openslide-bin from this ref
         required: false
         type: string
         default: main
@@ -78,8 +78,8 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@v4
         with:
-          repository: ${{ inputs.openslide_winbuild_repo }}
-          ref: ${{ inputs.openslide_winbuild_ref }}
+          repository: ${{ inputs.openslide_bin_repo }}
+          ref: ${{ inputs.openslide_bin_ref }}
 
       - name: Check out OpenSlide
         if: inputs.openslide_repo != ''
@@ -110,7 +110,7 @@ jobs:
       - name: Cache sources
         uses: actions/cache@v3
         with:
-          key: winbuild-tar
+          key: build-packagecache
           path: meson/subprojects/packagecache
       - name: Build source zip
         run: ./build.sh -p "${{ inputs.pkgver }}" sdist

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-# Build stable releases on push to openslide-winbuild main.
+# Build stable releases on push to openslide-bin main.
 # Nightly builds from Git are handled elsewhere.
 
 name: Build main
@@ -42,7 +42,7 @@ jobs:
     with:
       linux_builder_repo_and_digest: ${{ needs.setup.outputs.linux_builder_repo_and_digest }}
       macos_enable: true
-      openslide_winbuild_repo: ${{ github.repository }}
-      openslide_winbuild_ref: ${{ github.ref }}
+      openslide_bin_repo: ${{ github.repository }}
+      openslide_bin_ref: ${{ github.ref }}
       pkgver: ${{ needs.setup.outputs.pkgver }}
       windows_builder_repo_and_digest: ${{ needs.setup.outputs.windows_builder_repo_and_digest }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,4 +1,4 @@
-# PR CI workflow for openslide-winbuild
+# PR CI workflow for openslide-bin
 
 name: Build
 
@@ -41,8 +41,8 @@ jobs:
     with:
       linux_builder_repo_and_digest: ${{ needs.setup.outputs.linux_builder_repo_and_digest }}
       macos_enable: true
-      openslide_winbuild_repo: ${{ github.repository }}
-      openslide_winbuild_ref: ${{ github.ref }}
+      openslide_bin_repo: ${{ github.repository }}
+      openslide_bin_ref: ${{ github.ref }}
       pkgver: ${{ needs.setup.outputs.pkgver }}-stable
       windows_builder_repo_and_digest: ${{ needs.setup.outputs.windows_builder_repo_and_digest }}
 
@@ -57,8 +57,8 @@ jobs:
       openslide_ref: main
       openslide_java_repo: openslide/openslide-java
       openslide_java_ref: main
-      openslide_winbuild_repo: ${{ github.repository }}
-      openslide_winbuild_ref: ${{ github.ref }}
+      openslide_bin_repo: ${{ github.repository }}
+      openslide_bin_ref: ${{ github.ref }}
       pkgver: ${{ needs.setup.outputs.pkgver }}-git
       werror: true
       windows_builder_repo_and_digest: ${{ needs.setup.outputs.windows_builder_repo_and_digest }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,8 +43,8 @@ jobs:
     with:
       linux_builder_repo_and_digest: ${{ needs.setup.outputs.linux_builder_repo_and_digest }}
       macos_enable: true
-      openslide_winbuild_repo: ${{ github.repository }}
-      openslide_winbuild_ref: ${{ github.ref }}
+      openslide_bin_repo: ${{ github.repository }}
+      openslide_bin_ref: ${{ github.ref }}
       pkgver: ${{ needs.setup.outputs.pkgver }}
       windows_builder_repo_and_digest: ${{ needs.setup.outputs.windows_builder_repo_and_digest }}
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# openslide-winbuild
+# openslide-bin
 
 This is a set of scripts for building OpenSlide for Windows, including all
 of its dependencies, using MinGW-w64.

--- a/build.sh
+++ b/build.sh
@@ -152,7 +152,7 @@ tag_cachedir() {
         mkdir -p "$1"
         cat > "$1/CACHEDIR.TAG" <<EOF
 Signature: 8a477f597d28d172789f06886806bc55
-# This file is a cache directory tag created by openslide-winbuild.
+# This file is a cache directory tag created by openslide-bin.
 # For information about cache directory tags, see https://bford.info/cachedir/
 EOF
     fi

--- a/meson/include/setjmp.h
+++ b/meson/include/setjmp.h
@@ -12,7 +12,7 @@
  * pointer to skip the SEH unwind.  Our uses of setjmp/longjmp are all in
  * libpng/libjpeg error handling, which isn't expecting to do any cleanup
  * in intermediate stack frames, so this should be fine.
- * https://github.com/openslide/openslide-winbuild/issues/47
+ * https://github.com/openslide/openslide-bin/issues/47
  */
 #if defined _WIN32
 #undef setjmp

--- a/meson/meson.build
+++ b/meson/meson.build
@@ -1,5 +1,5 @@
 project(
-  'openslide-winbuild',
+  'openslide-bin',
   'c',
   license : 'LGPL-2.1-only',
   meson_version : '>=0.64',

--- a/meson/subprojects/packagecache/CACHEDIR.TAG
+++ b/meson/subprojects/packagecache/CACHEDIR.TAG
@@ -1,3 +1,3 @@
 Signature: 8a477f597d28d172789f06886806bc55
-# This file is a cache directory tag committed to the openslide-winbuild repo.
+# This file is a cache directory tag committed to the openslide-bin repo.
 # For information about cache directory tags, see https://bford.info/cachedir/


### PR DESCRIPTION
Don't rename build artifacts yet.

For https://github.com/openslide/openslide-winbuild/issues/159.