### PR TITLE
Clarify error if we don't find the container ABI flag

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -6,4 +6,5 @@
 - [ ] Verify that CI creates a [GitHub release](https://github.com/openslide/openslide-bin/releases/) with artifacts
 - [ ] Update website: `_data/releases.yaml`, maybe `_includes/news.md`
 - [ ] Possibly send mail to -announce and -users
+- [ ] Possibly post to [forum.image.sc](https://forum.image.sc/c/announcements/10)
 - [ ] Update `WINBUILD_RELEASE` in [OpenSlide Python CI](https://github.com/openslide/openslide-python/blob/main/.github/workflows/python.yml)

--- a/build.sh
+++ b/build.sh
@@ -431,7 +431,9 @@ updates() {
 probe() {
     # Probe the build environment and set up variables
     if [ ! -e /etc/openslide-winbuild-builder-v1 ] && [ ! -e /etc/openslide-winbuild-builder-v2 ]; then
-        echo "Must run inside the builder container.  See README.md."
+        echo "Not running in a compatible builder container.  Either build.sh isn't running"
+        echo "in the container (see instructions in README.md) or the container image is too"
+        echo "old or too new."
         exit 1
     fi
 

--- a/builder/linux/Dockerfile
+++ b/builder/linux/Dockerfile
@@ -1,5 +1,7 @@
 # Use a Linux distro with an older glibc for maximum compatibility
 FROM quay.io/almalinuxorg/almalinux:8
+# NOTE: try to keep the current container image compatible with the latest
+# stable source release, so people can conveniently build from the source zip
 RUN touch /etc/openslide-linux-builder-v1
 RUN dnf -y upgrade && \
     dnf -y install 'dnf-command(config-manager)' epel-release && \

--- a/builder/windows/Dockerfile
+++ b/builder/windows/Dockerfile
@@ -1,4 +1,6 @@
 FROM docker.io/gentoo/stage3:latest
+# NOTE: try to keep the current container image compatible with the latest
+# stable source release, so people can conveniently build from the source zip
 RUN touch /etc/openslide-winbuild-builder-v2
 RUN echo 'FEATURES="-sandbox -usersandbox -ipc-sandbox -network-sandbox -pid-sandbox"' >> /etc/portage/make.conf
 COPY package.accept_keywords /etc/portage/package.accept_keywords/cross


### PR DESCRIPTION
It's possible that we're running in the container, but the ABI version doesn't match.  Make that explicit.

Also note in the Dockerfiles that we shouldn't break container ABI for the most recent stable release.

For https://github.com/openslide/openslide-bin/issues/173.

Also, note in the release checklist that we should possibly announce to forum.image.sc.