### PR TITLE
README: improve instructions for building from Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,11 @@ of its dependencies, using MinGW-w64.
 ## Building
 
 The `builder/windows` directory defines a container image with the
-dependencies needed to run the build script.  To pull the container image
-and use it to run a build:
+dependencies needed to run the build script.  On Linux, or in Windows
+PowerShell with WSL 2, you can pull the container image and use it to run a
+build:
 
-    docker run -ti --rm -v $PWD:/work -w /work \
+    docker run -ti --rm -v ${PWD}:/work -w /work \
         ghcr.io/openslide/winbuild-builder ./build.sh bdist
 
 ## Substitute Sources


### PR DESCRIPTION
Clarify that builds can run from Linux or Windows and that the sample command uses PowerShell and not `cmd.exe` syntax.  Fix syntax error substituting `PWD` variable in PowerShell.

Fixes: https://github.com/openslide/openslide-bin/issues/181