### PR TITLE
builder/linux: add auditwheel and tomli

### DIFF
--- a/builder/linux/Dockerfile
+++ b/builder/linux/Dockerfile
@@ -9,4 +9,4 @@ RUN dnf -y upgrade && \
     dnf -y install gcc-c++ git-core java-1.8.0-openjdk-devel nasm ninja-build \
     patchelf python3.8 unzip && \
     dnf clean all
-RUN pip3 install meson
+RUN pip3 install auditwheel meson tomli


### PR DESCRIPTION
Needed for Python wheel support.  auditwheel is Linux-specific, and tomli is already included in the Windows builder container.  Neither is available via dnf.  (tomli is, but not for Python 3.8.)

For: https://github.com/openslide/openslide-bin/issues/160