### PR TITLE
Remove pass-through Meson options

### DIFF
--- a/.github/workflows/direct.yml
+++ b/.github/workflows/direct.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Build
         run: |
           meson setup build --native-file machines/native-linux-x86_64.ini \
-              -Dopenslide_werror=true
+              -Dopenslide:werror=true -Dopenslide-java:werror=true
           meson compile -C build
           DESTDIR=install meson install -C build
           mkdir output
@@ -65,7 +65,7 @@ jobs:
         run: |
           for arch in x86_64 arm64; do
               meson setup $arch --cross-file machines/cross-macos-${arch}.ini \
-                  -Dopenslide_werror=true
+                  -Dopenslide:werror=true -Dopenslide-java:werror=true
               meson compile -C $arch
               DESTDIR=install meson install -C $arch
           done

--- a/build.sh
+++ b/build.sh
@@ -210,7 +210,7 @@ build() {
         meson setup \
                 --cross-file "${cross_file}" \
                 "$build" \
-                ${ver_suffix:+-Dversion_suffix=${ver_suffix}} \
+                ${ver_suffix:+-Dopenslide:version_suffix=${ver_suffix}} \
                 ${openslide_werror}
     fi
     meson compile -C "$build" $parallel
@@ -475,7 +475,7 @@ do
         ver_suffix="${OPTARG}"
         ;;
     w)
-        openslide_werror="-Dopenslide_werror=true"
+        openslide_werror="-Dopenslide:werror=true -Dopenslide-java:werror=true"
         ;;
     esac
 done

--- a/deps/meson.build
+++ b/deps/meson.build
@@ -130,14 +130,11 @@ subproject(
     'default_library=shared',
     'doc=disabled',
     '_filter_external_symbols=true',
-    'version_suffix=' + get_option('version_suffix'),
-    'werror=' + get_option('openslide_werror').to_string(),
   ],
 )
 subproject(
   'openslide-java',
   default_options : [
     'embed_jni_path=disabled',
-    'werror=' + get_option('openslide_werror').to_string(),
   ],
 )

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,11 +1,4 @@
-option(
-  'openslide_werror',
-  type : 'boolean',
-  value : false,
-  description : 'Fail on compile warnings from OpenSlide/OpenSlide Java',
-)
-option(
-  'version_suffix',
-  type : 'string',
-  description : 'Suffix to append to the OpenSlide version string',
-)
+# useful subproject options:
+# -Dopenslide:version_suffix=foo - append foo to OpenSlide version string
+# -Dopenslide:werror=true        - fail OpenSlide build on warnings
+# -Dopenslide-java:werror=true   - fail OpenSlide Java build on warnings


### PR DESCRIPTION
The `openslide-bin` project doesn't directly use `openslide_werror` or `version_suffix`; it just passes them to some subprojects as `default_options`. However, these are _defaults_: they take effect during initial configuration, but if later changed with `meson setup --reconfigure` or `meson configure`, the new values aren't re-propagated to the subprojects. The abstraction thus encourages errors, and it doesn't really add much value in the first place.  Remove the top-level options and replace them with documentation about setting the corresponding subproject options directly.