### PR TITLE
workflows/direct: work around Python packaging bug in macOS runner

### DIFF
--- a/.github/workflows/direct.yml
+++ b/.github/workflows/direct.yml
@@ -52,6 +52,12 @@ jobs:
     steps:
       - name: Install dependencies
         run: |
+          # https://github.com/actions/setup-python/issues/577
+          # https://github.com/q3aiml/ledger/commit/f53b35ae
+          brew list -1 | grep python@ | while read formula; do
+              brew unlink $formula
+              brew link --overwrite $formula
+          done
           brew update
           brew install meson
       - name: Check out repo


### PR DESCRIPTION
Have Brew delete and recreate Python symlinks to avoid a conflict with a non-Brew Python installed in the Brew system path.