### PR TITLE
builder/linux: bump Python to 3.11

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
     hooks:
       - id: pyupgrade
         name: Modernize python code
-        args: ["--py38-plus"]
+        args: ["--py311-plus"]
 
   - repo: https://github.com/PyCQA/isort
     rev: 5.12.0

--- a/builder/linux/Dockerfile
+++ b/builder/linux/Dockerfile
@@ -7,6 +7,6 @@ RUN dnf -y upgrade && \
     dnf -y install 'dnf-command(config-manager)' epel-release && \
     dnf config-manager --set-enabled powertools && \
     dnf -y install gcc-c++ git-core java-1.8.0-openjdk-devel nasm ninja-build \
-    patchelf python3.8 unzip && \
+    patchelf python3.11-pip unzip && \
     dnf clean all
 RUN pip3 install auditwheel meson tomli

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.black]
 line-length = 79
 skip-string-normalization = true
-target-version = ["py38", "py39", "py310", "py311", "py312"]
+target-version = ["py311", "py312"]
 
 # https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html#flake8
 # requires Flake8-pyproject


### PR DESCRIPTION
The Windows builder already has 3.11, and on macOS we can reasonably assume it.  Drop configuration for older Python versions.