### PR TITLE
Rework archive names and version numbering; generate archives through Meson

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,10 @@
 # Shell scripts can't have CRLF line endings
 *.sh		eol=lf
+
+# Don't include Git/GitHub metadata and development tool configs in
+# sdist tarballs
+.gitattributes			export-ignore
+.gitignore			export-ignore
+/.github			export-ignore
+/.pre-commit-config.yaml	export-ignore
+/pyproject.toml			export-ignore

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -2,7 +2,7 @@
 
 - [ ] Run [workflow](https://github.com/openslide/openslide-bin/actions/workflows/update-check.yml) to check for updates
 - [ ] Merge any resulting PR; perform any needed manual updates reported by the workflow
-- [ ] Submit PR to update `CHANGELOG.md`
+- [ ] Submit PR to update `CHANGELOG.md` and `_PROJECT_VERSION`
 - [ ] Land PR
 - [ ] Create and push signed tag
 - [ ] Verify that CI creates a [GitHub release](https://github.com/openslide/openslide-bin/releases/) with release notes, software versions, and artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,6 @@ jobs:
     outputs:
       artifact: ${{ steps.prep.outputs.artifact }}
       version: ${{ steps.prep.outputs.version }}
-      version_suffix: ${{ steps.prep.outputs.version_suffix }}
     steps:
       - name: Check out repo
         uses: actions/checkout@v4
@@ -133,10 +132,6 @@ jobs:
           echo "artifact=$artifact" >> $GITHUB_OUTPUT
           mkdir -p "output/$artifact"
           mv "openslide-bin-${version}.tar.gz" "output/$artifact"
-          if [ -d override/openslide ]; then
-              suffix=$(git -C override/openslide rev-parse HEAD | cut -c-7)
-              echo "version_suffix=$suffix" >> $GITHUB_OUTPUT
-          fi
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
@@ -169,13 +164,11 @@ jobs:
         run: tar xf overrides.tar
       - name: Build binary zip
         run: |
-          suffix="${{ needs.sdist.outputs.version_suffix }}"
           werror=
           if [ "${{ inputs.werror }}" = true ]; then
               werror="-w"
           fi
-          ./build.sh ${suffix:+-s$suffix} -x "${{ inputs.suffix }}" \
-              $werror bdist
+          ./build.sh -x "${{ inputs.suffix }}" $werror bdist
           mkdir -p "output/${{ needs.sdist.outputs.artifact }}"
           mv "openslide-bin-${{ needs.sdist.outputs.version }}-windows-x64.zip" \
               "output/${{ needs.sdist.outputs.artifact }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,8 +43,8 @@ on:
         required: false
         type: string
         default: main
-      pkgver:
-        description: Set package version string
+      suffix:
+        description: Set package version suffix
         required: true
         type: string
       werror:
@@ -62,6 +62,9 @@ on:
       artifact:
         description: The name of the output artifact
         value: ${{ jobs.sdist.outputs.artifact }}
+      version:
+        description: The version of the output artifact
+        value: ${{ jobs.sdist.outputs.version }}
 
 permissions:
   contents: read
@@ -73,6 +76,7 @@ jobs:
     container: ${{ inputs.windows_builder_repo_and_digest }}
     outputs:
       artifact: ${{ steps.prep.outputs.artifact }}
+      version: ${{ steps.prep.outputs.version }}
       version_suffix: ${{ steps.prep.outputs.version_suffix }}
     steps:
       - name: Check out repo
@@ -119,14 +123,16 @@ jobs:
       - name: Build source tarball
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          ./build.sh -p "${{ inputs.pkgver }}" sdist
+          ./build.sh -x "${{ inputs.suffix }}" sdist
       - name: Prep artifact
         id: prep
         run: |
-          artifact="openslide-windows-${{ inputs.pkgver }}"
+          version=$(./build.sh -x "${{ inputs.suffix }}" version)
+          echo "version=$version" >> $GITHUB_OUTPUT
+          artifact="openslide-windows-${version}"
           echo "artifact=$artifact" >> $GITHUB_OUTPUT
           mkdir -p "output/$artifact"
-          mv "openslide-bin-${{ inputs.pkgver }}.tar.gz" "output/$artifact"
+          mv "openslide-bin-${version}.tar.gz" "output/$artifact"
           if [ -d override/openslide ]; then
               suffix=$(git -C override/openslide rev-parse HEAD | cut -c-7)
               echo "version_suffix=$suffix" >> $GITHUB_OUTPUT
@@ -150,8 +156,8 @@ jobs:
       - name: Unpack source tarball
         run: |
           (cd "${{ needs.sdist.outputs.artifact }}" &&
-              tar xf "openslide-bin-${{ inputs.pkgver }}.tar.gz")
-          mv "${{ needs.sdist.outputs.artifact }}/openslide-bin-${{ inputs.pkgver }}"/* .
+              tar xf "openslide-bin-${{ needs.sdist.outputs.version }}.tar.gz")
+          mv "${{ needs.sdist.outputs.artifact }}/openslide-bin-${{ needs.sdist.outputs.version }}"/* .
           rm -r "${{ needs.sdist.outputs.artifact }}"
       - name: Download overrides
         if: inputs.openslide_repo != '' || inputs.openslide_java_repo != ''
@@ -168,10 +174,10 @@ jobs:
           if [ "${{ inputs.werror }}" = true ]; then
               werror="-w"
           fi
-          ./build.sh ${suffix:+-s$suffix} -p "${{ inputs.pkgver }}" \
+          ./build.sh ${suffix:+-s$suffix} -x "${{ inputs.suffix }}" \
               $werror bdist
           mkdir -p "output/${{ needs.sdist.outputs.artifact }}"
-          mv "openslide-bin-${{ inputs.pkgver }}-windows-x64.zip" \
+          mv "openslide-bin-${{ needs.sdist.outputs.version }}-windows-x64.zip" \
               "output/${{ needs.sdist.outputs.artifact }}"
       - name: Upload artifact
         uses: actions/upload-artifact@v3
@@ -190,12 +196,12 @@ jobs:
           name: ${{ needs.sdist.outputs.artifact }}
       - name: Unpack artifact
         shell: bash
-        run: unzip "${{ needs.sdist.outputs.artifact }}/openslide-bin-${{ inputs.pkgver }}-windows-x64.zip"
+        run: unzip "${{ needs.sdist.outputs.artifact }}/openslide-bin-${{ needs.sdist.outputs.version }}-windows-x64.zip"
       - name: Report package versions
         shell: bash
-        run: cat "openslide-bin-${{ inputs.pkgver }}-windows-x64/VERSIONS.md" >> $GITHUB_STEP_SUMMARY
+        run: cat "openslide-bin-${{ needs.sdist.outputs.version }}-windows-x64/VERSIONS.md" >> $GITHUB_STEP_SUMMARY
       - name: Smoke test
         shell: bash
         run: |
-          cd "${GITHUB_WORKSPACE}/openslide-bin-${{ inputs.pkgver }}-windows-x64/bin"
+          cd "${GITHUB_WORKSPACE}/openslide-bin-${{ needs.sdist.outputs.version }}-windows-x64/bin"
           OPENSLIDE_DEBUG=synthetic ./slidetool.exe prop list ""

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -169,7 +169,7 @@ jobs:
           ./build.sh ${suffix:+-s$suffix} -p "${{ inputs.pkgver }}" \
               $werror bdist
           mkdir -p "output/${{ needs.sdist.outputs.artifact }}"
-          mv "openslide-win64-${{ inputs.pkgver }}.zip" \
+          mv "openslide-bin-${{ inputs.pkgver }}-windows-x64.zip" \
               "output/${{ needs.sdist.outputs.artifact }}"
       - name: Upload artifact
         uses: actions/upload-artifact@v3
@@ -188,12 +188,12 @@ jobs:
           name: ${{ needs.sdist.outputs.artifact }}
       - name: Unpack artifact
         shell: bash
-        run: unzip "${{ needs.sdist.outputs.artifact }}/openslide-win64-${{ inputs.pkgver }}.zip"
+        run: unzip "${{ needs.sdist.outputs.artifact }}/openslide-bin-${{ inputs.pkgver }}-windows-x64.zip"
       - name: Report package versions
         shell: bash
-        run: cat "openslide-win64-${{ inputs.pkgver }}/VERSIONS.md" >> $GITHUB_STEP_SUMMARY
+        run: cat "openslide-bin-${{ inputs.pkgver }}-windows-x64/VERSIONS.md" >> $GITHUB_STEP_SUMMARY
       - name: Smoke test
         shell: bash
         run: |
-          cd "${GITHUB_WORKSPACE}/openslide-win64-${{ inputs.pkgver }}/bin"
+          cd "${GITHUB_WORKSPACE}/openslide-bin-${{ inputs.pkgver }}-windows-x64/bin"
           OPENSLIDE_DEBUG=synthetic ./slidetool.exe prop list ""

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,7 +128,7 @@ jobs:
         run: |
           version=$(./build.sh -x "${{ inputs.suffix }}" version)
           echo "version=$version" >> $GITHUB_OUTPUT
-          artifact="openslide-windows-${version}"
+          artifact="openslide-bin-${version}"
           echo "artifact=$artifact" >> $GITHUB_OUTPUT
           mkdir -p "output/$artifact"
           mv "openslide-bin-${version}.tar.gz" "output/$artifact"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,7 @@ permissions:
 
 jobs:
   sdist:
-    name: Source zip
+    name: Source tarball
     runs-on: ubuntu-latest
     container: ${{ inputs.windows_builder_repo_and_digest }}
     outputs:
@@ -116,15 +116,17 @@ jobs:
         with:
           key: build-packagecache
           path: subprojects/packagecache
-      - name: Build source zip
-        run: ./build.sh -p "${{ inputs.pkgver }}" sdist
+      - name: Build source tarball
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          ./build.sh -p "${{ inputs.pkgver }}" sdist
       - name: Prep artifact
         id: prep
         run: |
           artifact="openslide-windows-${{ inputs.pkgver }}"
           echo "artifact=$artifact" >> $GITHUB_OUTPUT
           mkdir -p "output/$artifact"
-          mv "openslide-winbuild-${{ inputs.pkgver }}.zip" "output/$artifact"
+          mv "openslide-bin-${{ inputs.pkgver }}.tar.gz" "output/$artifact"
           if [ -d override/openslide ]; then
               suffix=$(git -C override/openslide rev-parse HEAD | cut -c-7)
               echo "version_suffix=$suffix" >> $GITHUB_OUTPUT
@@ -141,15 +143,15 @@ jobs:
     runs-on: ubuntu-latest
     container: ${{ inputs.windows_builder_repo_and_digest }}
     steps:
-      - name: Download source zip
+      - name: Download source tarball
         uses: actions/download-artifact@v3
         with:
           name: ${{ needs.sdist.outputs.artifact }}
-      - name: Unpack source zip
+      - name: Unpack source tarball
         run: |
           (cd "${{ needs.sdist.outputs.artifact }}" &&
-              unzip "openslide-winbuild-${{ inputs.pkgver }}.zip")
-          mv "${{ needs.sdist.outputs.artifact }}/openslide-winbuild-${{ inputs.pkgver }}"/* .
+              tar xf "openslide-bin-${{ inputs.pkgver }}.tar.gz")
+          mv "${{ needs.sdist.outputs.artifact }}/openslide-bin-${{ inputs.pkgver }}"/* .
           rm -r "${{ needs.sdist.outputs.artifact }}"
       - name: Download overrides
         if: inputs.openslide_repo != '' || inputs.openslide_java_repo != ''

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       linux_builder_repo_and_digest: ${{ steps.find-linux.outputs.builder_repo_and_digest }}
-      pkgver: ${{ steps.params.outputs.pkgver }}
+      suffix: ${{ steps.params.outputs.suffix }}
       windows_builder_repo_and_digest: ${{ steps.find-windows.outputs.builder_repo_and_digest }}
     steps:
       - name: Check out repo
@@ -45,7 +45,7 @@ jobs:
           builder_image: windows
       - name: Calculate parameters
         id: params
-        run: echo "pkgver=main-$(echo ${{ github.sha }} | cut -c-7)" >> $GITHUB_OUTPUT
+        run: echo "suffix=$(date +%Y%m%d).bin.main.$(echo ${{ github.sha }} | cut -c-7)" >> $GITHUB_OUTPUT
 
   stable:
     name: Stable
@@ -56,5 +56,5 @@ jobs:
       macos_enable: true
       openslide_bin_repo: ${{ github.repository }}
       openslide_bin_ref: ${{ github.ref }}
-      pkgver: ${{ needs.setup.outputs.pkgver }}
+      suffix: ${{ needs.setup.outputs.suffix }}
       windows_builder_repo_and_digest: ${{ needs.setup.outputs.windows_builder_repo_and_digest }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       linux_builder_repo_and_digest: ${{ steps.find-linux.outputs.builder_repo_and_digest }}
-      pkgver: ${{ steps.params.outputs.pkgver }}
+      suffix: ${{ steps.params.outputs.suffix }}
       windows_builder_repo_and_digest: ${{ steps.find-windows.outputs.builder_repo_and_digest }}
     steps:
       - name: Check out repo
@@ -44,7 +44,7 @@ jobs:
           builder_image: windows
       - name: Calculate parameters
         id: params
-        run: echo "pkgver=pr-${{ github.event.number }}.${{ github.run_number }}.${{ github.run_attempt }}-$(echo ${{ github.sha }} | cut -c-7)" >> $GITHUB_OUTPUT
+        run: echo "suffix=$(date +%Y%m%d).bin.pr.${{ github.event.number }}.${{ github.run_number }}.${{ github.run_attempt }}.$(echo ${{ github.sha }} | cut -c-7)" >> $GITHUB_OUTPUT
 
   stable:
     name: Stable
@@ -55,7 +55,7 @@ jobs:
       macos_enable: true
       openslide_bin_repo: ${{ github.repository }}
       openslide_bin_ref: ${{ github.ref }}
-      pkgver: ${{ needs.setup.outputs.pkgver }}-stable
+      suffix: ${{ needs.setup.outputs.suffix }}.stable
       windows_builder_repo_and_digest: ${{ needs.setup.outputs.windows_builder_repo_and_digest }}
 
   git:
@@ -71,6 +71,6 @@ jobs:
       openslide_java_ref: main
       openslide_bin_repo: ${{ github.repository }}
       openslide_bin_ref: ${{ github.ref }}
-      pkgver: ${{ needs.setup.outputs.pkgver }}-git
+      suffix: ${{ needs.setup.outputs.suffix }}.git
       werror: true
       windows_builder_repo_and_digest: ${{ needs.setup.outputs.windows_builder_repo_and_digest }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
 
           gh release create --latest --verify-tag \
               --repo "${{ github.repository }}" \
-              --title "Windows build ${{ needs.stable.outputs.version }}" \
+              --title "openslide-bin ${{ needs.stable.outputs.version }}" \
               --notes-file changes \
               "${{ github.ref_name }}" \
               "${{ needs.stable.outputs.artifact }}/"*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       linux_builder_repo_and_digest: ${{ steps.find-linux.outputs.builder_repo_and_digest }}
-      pkgver: ${{ steps.params.outputs.pkgver }}
       windows_builder_repo_and_digest: ${{ steps.find-windows.outputs.builder_repo_and_digest }}
     steps:
       - name: Check out repo
@@ -32,9 +31,6 @@ jobs:
         uses: ./.github/find-container-digest
         with:
           builder_image: windows
-      - name: Calculate parameters
-        id: params
-        run: echo "pkgver=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
 
   stable:
     name: Stable
@@ -45,7 +41,7 @@ jobs:
       macos_enable: true
       openslide_bin_repo: ${{ github.repository }}
       openslide_bin_ref: ${{ github.ref }}
-      pkgver: ${{ needs.setup.outputs.pkgver }}
+      suffix: ""
       windows_builder_repo_and_digest: ${{ needs.setup.outputs.windows_builder_repo_and_digest }}
 
   release:
@@ -63,7 +59,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          unzip "${{ needs.stable.outputs.artifact }}/openslide-bin-${{ needs.setup.outputs.pkgver }}-windows-x64.zip"
+          unzip "${{ needs.stable.outputs.artifact }}/openslide-bin-${{ needs.stable.outputs.version }}-windows-x64.zip"
 
           echo "## Changes" > changes
           awk -e '/^## / && ok {exit}' \
@@ -72,12 +68,12 @@ jobs:
               "openslide-win64-${{ needs.setup.outputs.pkgver }}/CHANGELOG.md" \
               >> changes
           echo -e "## Versions\n" >> changes
-          cat "openslide-bin-${{ needs.setup.outputs.pkgver }}-windows-x64/VERSIONS.md" \
+          cat "openslide-bin-${{ needs.stable.outputs.version }}-windows-x64/VERSIONS.md" \
               >> changes
 
           gh release create --latest --verify-tag \
               --repo "${{ github.repository }}" \
-              --title "Windows build ${{ needs.setup.outputs.pkgver }}" \
+              --title "Windows build ${{ needs.stable.outputs.version }}" \
               --notes-file changes \
               "${{ github.ref_name }}" \
               "${{ needs.stable.outputs.artifact }}/"*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          unzip "${{ needs.stable.outputs.artifact }}/openslide-win64-${{ needs.setup.outputs.pkgver }}.zip"
+          unzip "${{ needs.stable.outputs.artifact }}/openslide-bin-${{ needs.setup.outputs.pkgver }}-windows-x64.zip"
 
           echo "## Changes" > changes
           awk -e '/^## / && ok {exit}' \
@@ -72,7 +72,7 @@ jobs:
               "openslide-win64-${{ needs.setup.outputs.pkgver }}/CHANGELOG.md" \
               >> changes
           echo -e "## Versions\n" >> changes
-          cat "openslide-win64-${{ needs.setup.outputs.pkgver }}/VERSIONS.md" \
+          cat "openslide-bin-${{ needs.setup.outputs.pkgver }}-windows-x64/VERSIONS.md" \
               >> changes
 
           gh release create --latest --verify-tag \

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 64
 override
 openslide-win*
+openslide-bin-*
 
 __pycache__
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 64
 override
-openslide-win*
 openslide-bin-*
 
 __pycache__

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ can be obtained by running `build.sh` with no arguments.
 
 #### `sdist`
 
-Build Zip file containing build system and sources for OpenSlide and all
-dependencies.
+Build `tar.gz` file containing build system and sources for OpenSlide and
+all dependencies.
 
 #### `bdist`
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ those packages in the specified bitness.
 
 Check for new releases of software packages.
 
+#### `version`
+
+Report the version number that will be used in archive file names.
+
 ## Options
 
 These must be specified before the subcommand.
@@ -49,10 +53,6 @@ These must be specified before the subcommand.
 
 Parallel build with the specified parallelism.
 
-#### `-p<pkgver>`
-
-Set package version string in Zip file names to `pkgver`.
-
 #### `-s<suffix>`
 
 Append `suffix` to the OpenSlide version string.
@@ -60,3 +60,7 @@ Append `suffix` to the OpenSlide version string.
 #### `-w`
 
 Treat OpenSlide and OpenSlide Java build warnings as errors.
+
+#### `-x<suffix>`
+
+Set version number suffix in archive file names to `suffix`.

--- a/README.md
+++ b/README.md
@@ -53,10 +53,6 @@ These must be specified before the subcommand.
 
 Parallel build with the specified parallelism.
 
-#### `-s<suffix>`
-
-Append `suffix` to the OpenSlide version string.
-
 #### `-w`
 
 Treat OpenSlide and OpenSlide Java build warnings as errors.

--- a/artifacts/meson.build
+++ b/artifacts/meson.build
@@ -25,9 +25,6 @@ else
   env.set('OBJDUMP', find_program('objdump').full_path())
 endif
 
-fs = import('fs')
-openslide_jar = openslide_java.get_variable('openslide_jar')
-artifact_dir = get_option('prefix') / 'artifacts'
 artifacts = [
   custom_target(
     command : [find_program('write-project-versions.py'), '-o', '@OUTPUT@'],
@@ -35,16 +32,10 @@ artifacts = [
     # ensure we regenerate after dependency updates
     build_always_stale : true,
     env : env,
-    install : true,
-    install_dir : get_option('datadir'),
   ),
-  custom_target(
-    command : ['cp', '@INPUT@', '@OUTPUT@'],
-    input : openslide_jar,
-    output : fs.name(openslide_jar.full_path()),
-    install : true,
-    install_dir : artifact_dir,
-  ),
+  openslide.get_variable('openslide_headers'),
+  openslide_java.get_variable('openslide_jar'),
+  meson.project_source_root() / 'CHANGELOG.md',
 ]
 
 licenses = custom_target(
@@ -53,8 +44,6 @@ licenses = custom_target(
   # ensure we regenerate after dependency updates
   build_always_stale : true,
   env : env,
-  install : true,
-  install_dir : get_option('datadir'),
 )
 artifacts += licenses
 
@@ -67,11 +56,10 @@ if system == 'windows'
     input : libopenslide,
     output : 'libopenslide.lib',
     env : env,
-    install : true,
-    install_dir : artifact_dir,
   )
 endif
 
+fs = import('fs')
 postprocess = find_program('postprocess-binary.py')
 foreach bin : [
   libopenslide,
@@ -84,7 +72,20 @@ foreach bin : [
     input : bin,
     output : [name, name + (system == 'darwin' ? '.dSYM' : '.debug')],
     env : env,
-    install : true,
-    install_dir : artifact_dir,
   )
 endforeach
+
+custom_target(
+  command : [
+    find_program('write-bdist.py'), '-o', '@OUTPUT@', '@INPUT@'
+  ],
+  input : artifacts,
+  output : '@0@-@1@-@2@.@3@'.format(
+    meson.project_name(),
+    meson.project_version(),
+    meson.get_external_property('openslide_bin_platform'),
+    system == 'windows' ? 'zip' : 'tar.xz'
+  ),
+  env : env,
+  build_by_default : true,
+)

--- a/artifacts/meson.build
+++ b/artifacts/meson.build
@@ -25,6 +25,10 @@ else
   env.set('OBJDUMP', find_program('objdump').full_path())
 endif
 
+meson.add_dist_script(
+  files('postprocess-sdist.py'), '-i', mesonintrospect
+)
+
 artifacts = [
   custom_target(
     command : [find_program('write-project-versions.py'), '-o', '@OUTPUT@'],

--- a/artifacts/postprocess-sdist.py
+++ b/artifacts/postprocess-sdist.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+#
+# Tools for building OpenSlide and its dependencies
+#
+# Copyright (c) 2023 Benjamin Gilbert
+# All rights reserved.
+#
+# This script is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License, version 2.1,
+# as published by the Free Software Foundation.
+#
+# This script is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this script. If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import sys
+
+# handle our own PYTHONPATH prepending, since meson can't set environment
+# variables for dist scripts
+# flake8 isn't happy about this
+sys.path.insert(0, os.environ['MESON_SOURCE_ROOT'])
+
+from common.argparse import TypedArgs  # noqa: E402
+from common.meson import meson_introspect  # noqa: E402
+
+
+class Args(TypedArgs):
+    introspect: str
+
+
+args = Args(
+    'postprocess-sdist', description='Modify sdist directory before packing.'
+)
+args.add_arg(
+    '-i', '--introspect', required=True, help='Meson introspect command'
+)
+args.parse()
+os.environ['MESONINTROSPECT'] = args.introspect
+dest = Path(os.environ['MESON_DIST_ROOT'])
+
+# pin openslide-bin version
+version: str = meson_introspect('projectinfo')['version']
+(dest / 'version').write_text(version + '\n')

--- a/artifacts/postprocess-sdist.py
+++ b/artifacts/postprocess-sdist.py
@@ -47,6 +47,10 @@ args.parse()
 os.environ['MESONINTROSPECT'] = args.introspect
 dest = Path(os.environ['MESON_DIST_ROOT'])
 
-# pin openslide-bin version
+# pin openslide-bin version suffix
 version: str = meson_introspect('projectinfo')['version']
-(dest / 'version').write_text(version + '\n')
+try:
+    suffix = version.split('+', 1)[1]
+except IndexError:
+    suffix = ''
+(dest / 'suffix').write_text(suffix + '\n')

--- a/artifacts/write-bdist.py
+++ b/artifacts/write-bdist.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+#
+# Tools for building OpenSlide and its dependencies
+#
+# Copyright (c) 2023 Benjamin Gilbert
+# All rights reserved.
+#
+# This script is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License, version 2.1,
+# as published by the Free Software Foundation.
+#
+# This script is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this script. If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path, PurePath
+import re
+from typing import BinaryIO
+
+from common.archive import (
+    ArchiveWriter,
+    FileMember,
+    SymlinkMember,
+    TarArchiveWriter,
+    ZipArchiveWriter,
+)
+from common.argparse import TypedArgs
+from common.meson import meson_host
+from common.software import Project
+
+
+class Args(TypedArgs):
+    artifacts: list[Path]
+    output: BinaryIO
+
+
+args = Args('write-bdist', description='Write bdist archive.')
+args.add_arg(
+    '-o',
+    '--output',
+    type=argparse.FileType('wb'),
+    required=True,
+    help='output file',
+)
+args.add_arg(
+    'artifacts',
+    metavar='artifact',
+    nargs='+',
+    type=Path,
+    help='built artifact',
+)
+args.parse()
+
+if meson_host() == 'windows':
+    arc: ArchiveWriter = ZipArchiveWriter(args.output)
+else:
+    arc = TarArchiveWriter(args.output)
+with arc:
+    for path in args.artifacts:
+        name = path.name
+        if re.search(
+            '\\.(lib|(dylib|jnilib)(\\.dSYM)?|so[.0-9]*(\\.debug)?)$', name
+        ):
+            arcdir = arc.base / 'lib'
+        elif name.endswith('.h'):
+            arcdir = arc.base / 'include' / 'openslide'
+        elif name.endswith('.jar'):
+            if meson_host() == 'windows':
+                arcdir = arc.base / 'bin'
+            else:
+                arcdir = arc.base / 'lib'
+        elif name in ('CHANGELOG.md', 'VERSIONS.md', 'licenses'):
+            arcdir = arc.base
+        else:
+            arcdir = arc.base / 'bin'
+
+        if path.is_dir():
+            arc.add_tree(arcdir, path)
+        else:
+            arc.add(FileMember(arcdir / name, path.open('rb')))
+            if re.search('\\.so(\\.[0-9]+){3}$', name):
+                for pat in '(\\.[0-9]+){2}$', '(\\.[0-9]+)+$':
+                    lname = re.sub(pat, '', name)
+                    arc.add(SymlinkMember(arcdir / lname, PurePath(name)))
+            elif re.search('\\.[0-9]+\\.dylib$', name):
+                lname = re.sub('\\.[0-9]+\\.dylib$', '.dylib', name)
+                arc.add(SymlinkMember(arcdir / lname, PurePath(name)))
+
+    # special case: copy OpenSlide README to root
+    arc.add(
+        FileMember(
+            arc.base / 'README.md',
+            open(Project.get('openslide').source_dir / 'README.md', 'rb'),
+        )
+    )

--- a/build.sh
+++ b/build.sh
@@ -284,6 +284,10 @@ probe() {
     fi
     pkgver="$(MESON_SOURCE_ROOT=. python3 utils/get-version.py)"
 
+    if [ -d override/openslide ]; then
+        ver_suffix=$(git -C override/openslide rev-parse HEAD | cut -c-7)
+    fi
+
     sbuild=64/sdist
     build=64/build
     cross_file="machines/cross-windows-x64.ini"
@@ -302,16 +306,12 @@ trap fail_handler ERR
 # Parse command-line options
 parallel=""
 pkg_suffix="-DEFAULT-"
-ver_suffix=""
 openslide_werror=""
-while getopts "j:s:wx:" opt
+while getopts "j:wx:" opt
 do
     case "$opt" in
     j)
         parallel="-j${OPTARG}"
-        ;;
-    s)
-        ver_suffix="${OPTARG}"
         ;;
     w)
         openslide_werror="-Dopenslide:werror=true -Dopenslide-java:werror=true"
@@ -355,7 +355,7 @@ version)
 *)
     cat <<EOF
 Usage: $0 [-x<suffix>] sdist
-       $0 [-j<n>] [-s<suffix>] [-w] [-x<suffix>] bdist
+       $0 [-j<n>] [-w] [-x<suffix>] bdist
        $0 clean [package...]
        $0 updates
        $0 [-x<suffix>] version

--- a/common/archive.py
+++ b/common/archive.py
@@ -1,0 +1,162 @@
+#
+# Tools for building OpenSlide and its dependencies
+#
+# Copyright (c) 2023 Benjamin Gilbert
+# All rights reserved.
+#
+# This script is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License, version 2.1,
+# as published by the Free Software Foundation.
+#
+# This script is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this script. If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+import os
+from pathlib import Path, PurePath
+import re
+import tarfile
+import time
+from types import TracebackType
+from typing import BinaryIO, Self
+import zipfile
+
+
+@dataclass
+class Member(ABC):
+    path: PurePath
+
+
+@dataclass
+class FileMember(Member):
+    fh: BinaryIO
+
+
+@dataclass
+class DirMember(Member):
+    pass
+
+
+@dataclass
+class SymlinkMember(Member):
+    target: PurePath
+
+
+class ArchiveWriter(ABC):
+    def __init__(self, path: Path):
+        self.base = PurePath(re.sub('\\.(tar\\.xz|zip)$', '', path.name))
+        self._members: dict[PurePath, Member] = {}
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        self.close()
+
+    @abstractmethod
+    def close(self) -> None:
+        pass
+
+    def add(self, member: Member) -> None:
+        assert member.path not in self._members
+        self._members[member.path] = member
+        path = member.path.parent
+        while path != PurePath('.'):
+            parent = self._members.setdefault(path, DirMember(path))
+            assert isinstance(parent, DirMember)
+            path = path.parent
+
+    def add_tree(self, arcdir: PurePath, path: Path) -> None:
+        def walkerr(e: OSError) -> None:
+            raise e
+
+        for dpath_str, _, fnames in os.walk(path, onerror=walkerr):
+            dpath = Path(dpath_str)
+            for fname in fnames:
+                self.add(
+                    FileMember(
+                        arcdir / dpath.relative_to(path.parent) / fname,
+                        open(dpath / fname, 'rb'),
+                    )
+                )
+
+
+class TarArchiveWriter(ArchiveWriter):
+    def __init__(self, fh: BinaryIO):
+        super().__init__(Path(fh.name))
+        self._tar = tarfile.open(
+            fileobj=fh,
+            mode='w:xz',
+            format=tarfile.PAX_FORMAT,
+            preset=9,  # type: ignore[call-arg]
+        )
+        self._now = int(time.time())
+
+    def close(self) -> None:
+        for _, member in sorted(self._members.items()):
+            if isinstance(member, FileMember):
+                info = self._tar.gettarinfo(
+                    arcname=member.path.as_posix(), fileobj=member.fh
+                )
+                info.mode = info.mode & ~0o022 | 0o644
+                info.uid = 0
+                info.gid = 0
+                info.uname = 'root'
+                info.gname = 'root'
+                self._tar.addfile(info, member.fh)
+            elif isinstance(member, DirMember):
+                info = tarfile.TarInfo(member.path.as_posix())
+                info.mtime = self._now
+                info.mode = 0o755
+                info.type = tarfile.DIRTYPE
+                info.uname = 'root'
+                info.gname = 'root'
+                self._tar.addfile(info)
+            elif isinstance(member, SymlinkMember):
+                info = tarfile.TarInfo(member.path.as_posix())
+                info.mtime = self._now
+                info.mode = 0o777
+                info.type = tarfile.SYMTYPE
+                info.linkname = member.target.as_posix()
+                info.uname = 'root'
+                info.gname = 'root'
+                self._tar.addfile(info)
+        self._tar.close()
+
+
+class ZipArchiveWriter(ArchiveWriter):
+    def __init__(self, fh: BinaryIO):
+        super().__init__(Path(fh.name))
+        self._zip = zipfile.ZipFile(
+            fh, 'w', compression=zipfile.ZIP_DEFLATED, compresslevel=9
+        )
+
+    def close(self) -> None:
+        for _, member in sorted(self._members.items()):
+            if isinstance(member, FileMember):
+                try:
+                    info: str | zipfile.ZipInfo = zipfile.ZipInfo.from_file(
+                        member.fh.name, member.path
+                    )
+                except AttributeError:
+                    info = member.path.as_posix()
+                self._zip.writestr(info, member.fh.read())
+            elif isinstance(member, DirMember):
+                self._zip.writestr(member.path.as_posix() + '/', b'')
+            elif isinstance(member, SymlinkMember):
+                raise Exception('Symlinks not supported in Zip')
+        self._zip.close()

--- a/common/meson.py
+++ b/common/meson.py
@@ -25,9 +25,16 @@ from functools import lru_cache
 import json
 import os
 from pathlib import Path
+import re
 import shlex
 import subprocess
 from typing import Any
+
+# A.B.C.D
+# A.B.C = OpenSlide version
+# D = ordinal of the openslide-bin release with this A.B.C, starting from 1
+# Update the version when releasing openslide-bin.
+_PROJECT_VERSION = '4.0.0.1'
 
 
 def meson_source_root() -> Path:
@@ -53,13 +60,23 @@ def parse_ini_file(path: Path) -> configparser.RawConfigParser:
         return ini
 
 
-def default_version() -> str:
-    # try the version pinned by 'meson dist'
+def project_version(suffix: str) -> str:
+    if not re.match('[a-zA-Z0-9.]*$', suffix):
+        raise Exception('Invalid character in version suffix')
+    if suffix:
+        return f'{_PROJECT_VERSION}+{suffix}'
+    else:
+        return _PROJECT_VERSION
+
+
+def default_suffix() -> str:
+    # try the suffix pinned by 'meson dist'
     try:
-        ver = (meson_source_root() / 'version').read_text().strip()
-        # append "-local" if missing
-        if '-local' not in ver:
-            ver += '-local'
-        return ver
+        suffix = (meson_source_root() / 'suffix').read_text().strip()
+        segments = suffix.split('.') if suffix else []
+        # append "local" segment if missing
+        if 'local' not in segments:
+            segments.append('local')
+        return '.'.join(segments)
     except FileNotFoundError:
-        return date.today().strftime('%Y%m%d') + '-local'
+        return date.today().strftime('%Y%m%d') + '.local'

--- a/common/meson.py
+++ b/common/meson.py
@@ -54,4 +54,12 @@ def parse_ini_file(path: Path) -> configparser.RawConfigParser:
 
 
 def default_version() -> str:
-    return date.today().strftime('%Y%m%d') + '-local'
+    # try the version pinned by 'meson dist'
+    try:
+        ver = (meson_source_root() / 'version').read_text().strip()
+        # append "-local" if missing
+        if '-local' not in ver:
+            ver += '-local'
+        return ver
+    except FileNotFoundError:
+        return date.today().strftime('%Y%m%d') + '-local'

--- a/common/software.py
+++ b/common/software.py
@@ -40,6 +40,13 @@ class Project:
     primary: bool = False
 
     @staticmethod
+    def get(id: str) -> Project:
+        for p in _PROJECTS:
+            if p.id == id:
+                return p
+        raise KeyError
+
+    @staticmethod
     def get_enabled() -> list[Project]:
         enabled = {
             s['name'] for s in meson_introspect('projectinfo')['subprojects']

--- a/deps/meson.build
+++ b/deps/meson.build
@@ -1,9 +1,13 @@
+# should we enable all subprojects?  this is needed when building source
+# distributions so we don't leave anything out
+force_subprojects = get_option('all_subprojects')
+
 add_global_arguments(
   '-I' + meson.current_source_dir(),
   language: ['c', 'cpp']
 )
 
-if system == 'darwin'
+if system == 'darwin' and not force_subprojects
   cc = meson.get_compiler('c')
   # [dependency name, library name, version] or
   # [dependency name, library name, header with version, version define]
@@ -53,7 +57,7 @@ else
   subproject('sqlite3')
 endif
 
-if system != 'linux'
+if system != 'linux' or force_subprojects
   subproject('proxy-libintl')
 endif
 

--- a/machines/cross-macos-arm64.ini
+++ b/machines/cross-macos-arm64.ini
@@ -12,6 +12,7 @@ pkg_config_path = ''
 # Use only our pkg-config library directory, even on cross builds
 # https://bugzilla.redhat.com/show_bug.cgi?id=688171
 pkg_config_libdir = '/lib/pkgconfig'
+openslide_bin_platform = 'macos-arm64'
 
 [binaries]
 c = 'clang'

--- a/machines/cross-macos-x86_64.ini
+++ b/machines/cross-macos-x86_64.ini
@@ -12,6 +12,7 @@ pkg_config_path = ''
 # Use only our pkg-config library directory, even on cross builds
 # https://bugzilla.redhat.com/show_bug.cgi?id=688171
 pkg_config_libdir = '/lib/pkgconfig'
+openslide_bin_platform = 'macos-x86_64'
 
 [binaries]
 c = 'clang'

--- a/machines/cross-windows-x64.ini
+++ b/machines/cross-windows-x64.ini
@@ -10,6 +10,7 @@ pkg_config_path = ''
 # Use only our pkg-config library directory, even on cross builds
 # https://bugzilla.redhat.com/show_bug.cgi?id=688171
 pkg_config_libdir = '/lib/pkgconfig'
+openslide_bin_platform = 'windows-x64'
 
 [binaries]
 ar = 'x86_64-w64-mingw32-ar'

--- a/machines/native-linux-x86_64.ini
+++ b/machines/native-linux-x86_64.ini
@@ -8,3 +8,4 @@ pkg_config_path = ''
 
 [properties]
 pkg_config_libdir = '/native/lib/pkgconfig'
+openslide_bin_platform = 'linux-x86_64'

--- a/meson.options
+++ b/meson.options
@@ -2,3 +2,10 @@
 # -Dopenslide:version_suffix=foo - append foo to OpenSlide version string
 # -Dopenslide:werror=true        - fail OpenSlide build on warnings
 # -Dopenslide-java:werror=true   - fail OpenSlide Java build on warnings
+
+option(
+  'all_subprojects',
+  type : 'boolean',
+  value : false,
+  description : 'Enable all subprojects (for building the source tarball)',
+)

--- a/utils/get-version.py
+++ b/utils/get-version.py
@@ -27,9 +27,7 @@ import sys
 # flake8 isn't happy about this
 sys.path.insert(0, os.environ['MESON_SOURCE_ROOT'])
 
-from common.meson import default_version  # noqa: E402
+from common.meson import default_suffix, project_version  # noqa: E402
 
-ver = os.environ.get('OPENSLIDE_BIN_VERSION')
-if not ver:
-    ver = default_version()
-print(ver)
+suffix = os.environ.get('OPENSLIDE_BIN_SUFFIX', default_suffix())
+print(project_version(suffix))


### PR DESCRIPTION
Change sdist names to `openslide-bin-<version>.tar.gz` and bdist names to `openslide-bin-<version>-<platform>-<arch>.<ext>` (currently `-windows-x64.zip`).

Change versions to `<openslide-version>.<release>+<suffix>`, e.g. `4.0.0.1+20231207.nightly`, for clarity and for compatibility with [Python package versioning](https://packaging.python.org/en/latest/specifications/version-specifiers/).

Generate bdist archives as a Meson artifact, rather than in `build.sh`, allowing us to avoid the `meson install` step.

Generate sdist archives with `meson dist` rather than building them ourselves.  Switch the archive format to `tar.gz` for compatibility with Python source distributions.  Meson distributes subproject sources as unpacked file trees, so we lose some compression ratio this way, but the difference isn't too substantial.  Embed the configured version suffix in the sdist archive and reuse it by default (with `.local` appended) during bdist.

Drop the `-s` option for suffixing OpenSlide's version string, and do this automatically from the OpenSlide commit hash if OpenSlide is overridden.