### PR TITLE
find-container-digest: fix invoking from other repos

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,9 +2,12 @@
 *.sh		eol=lf
 
 # Don't include Git/GitHub metadata and development tool configs in
-# sdist tarballs
+# sdist tarballs.
+# Don't ignore the find-container-digest composite action; remove it from
+# postprocess-sdist.py.  This is necessary so other repos can use the action.
 .gitattributes			export-ignore
 .gitignore			export-ignore
-/.github			export-ignore
+/.github/ISSUE_TEMPLATE		export-ignore
+/.github/workflows		export-ignore
 /.pre-commit-config.yaml	export-ignore
 /pyproject.toml			export-ignore

--- a/artifacts/postprocess-sdist.py
+++ b/artifacts/postprocess-sdist.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+import shutil
 import sys
 
 # handle our own PYTHONPATH prepending, since meson can't set environment
@@ -46,6 +47,9 @@ args.add_arg(
 args.parse()
 os.environ['MESONINTROSPECT'] = args.introspect
 dest = Path(os.environ['MESON_DIST_ROOT'])
+
+# remove those parts of .github not ignored from .gitattributes
+shutil.rmtree(dest / '.github')
 
 # pin openslide-bin version suffix
 version: str = meson_introspect('projectinfo')['version']


### PR DESCRIPTION
If we `export-ignore` the action, it can't be used from other repos. Continue export-ignoring other children of `.github`, to keep raw exports (e.g. GitHub source Zips) relatively clean, and then remove the action from `postprocess-sdist.py`.

Fixes c8c9c063a2.