### PR TITLE
Add tool for combining macOS builds into universal build

### DIFF
--- a/.github/workflows/direct.yml
+++ b/.github/workflows/direct.yml
@@ -25,27 +25,25 @@ jobs:
           key: direct-cache
           path: subprojects/packagecache
       - name: Build
+        id: build
         run: |
           meson setup build --native-file machines/native-linux-x86_64.ini \
               -Dopenslide:werror=true -Dopenslide-java:werror=true
           meson compile -C build
-          DESTDIR=install meson install -C build
-          mkdir output
-          cp build/install/{bin/slidetool,lib64/libopenslide.so.1} output/
-          cd output
-          for f in libopenslide.so.1 slidetool; do
-              objcopy --only-keep-debug $f ${f}.debug
-              objcopy -S --add-gnu-debuglink=${f}.debug $f ${f}.new
-              mv ${f}.new $f
-          done
-          patchelf --set-rpath '$ORIGIN' slidetool
+          artifact=$(cd build/artifacts && echo openslide-bin-*-linux-x86_64.tar.xz)
+          mv "build/artifacts/$artifact" .
+          echo "artifact=$artifact" >> $GITHUB_OUTPUT
       - name: Smoke test
-        run: OPENSLIDE_DEBUG=synthetic output/slidetool prop list ''
+        run: |
+          tar xf "${{ steps.build.outputs.artifact }}"
+          OPENSLIDE_DEBUG=synthetic \
+              openslide-bin-*-linux-x86_64/bin/slidetool prop list ''
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: linux
-          path: output
+          name: ${{ steps.build.outputs.artifact }}
+          path: ${{ steps.build.outputs.artifact }}
+          compression-level: 0
   macos:
     name: macOS
     runs-on: macos-latest
@@ -68,29 +66,28 @@ jobs:
           key: direct-cache
           path: subprojects/packagecache
       - name: Build
+        id: build
         run: |
+          export OPENSLIDE_BIN_SUFFIX="$(date +%Y%m%d).local"
+          version=$(MESON_SOURCE_ROOT=$(pwd) python3 utils/get-version.py)
           for arch in x86_64 arm64; do
               meson setup $arch --cross-file machines/cross-macos-${arch}.ini \
                   -Dopenslide:werror=true -Dopenslide-java:werror=true
               meson compile -C $arch
-              DESTDIR=install meson install -C $arch
           done
-          mkdir output
-          lipo -create {x86_64,arm64}/install/lib/libopenslide.1.dylib \
-              -output output/libopenslide.1.dylib
-          lipo -create {x86_64,arm64}/install/bin/slidetool \
-              -output output/slidetool
-          cd output
-          for f in libopenslide.1.dylib slidetool; do
-              dsymutil $f
-              strip -u -r $f
-          done
-          install_name_tool -change /lib/libopenslide.1.dylib \
-              '@loader_path/libopenslide.1.dylib' slidetool
+          artifact="openslide-bin-${version}-macos-arm64-x86_64.tar.xz"
+          PYTHONPATH=. python3 utils/write-universal-bdist.py \
+              -o "$artifact" \
+              */artifacts/openslide-bin-"${version}"-macos-*.tar.xz
+          echo "artifact=$artifact" >> $GITHUB_OUTPUT
       - name: Smoke test
-        run: OPENSLIDE_DEBUG=synthetic output/slidetool prop list ''
+        run: |
+          tar xf "${{ steps.build.outputs.artifact }}"
+          OPENSLIDE_DEBUG=synthetic \
+              openslide-bin-*-macos-arm64-x86_64/bin/slidetool prop list ''
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: macos
-          path: output
+          name: ${{ steps.build.outputs.artifact }}
+          path: ${{ steps.build.outputs.artifact }}
+          compression-level: 0

--- a/common/macos.py
+++ b/common/macos.py
@@ -1,0 +1,45 @@
+#
+# Tools for building OpenSlide and its dependencies
+#
+# Copyright (c) 2023 Benjamin Gilbert
+# All rights reserved.
+#
+# This script is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License, version 2.1,
+# as published by the Free Software Foundation.
+#
+# This script is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this script. If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+import os
+from pathlib import Path
+import subprocess
+from typing import Any
+
+
+def merge_macho(paths: Sequence[Path], outdir: Path) -> Path:
+    outpath = outdir / paths[0].name
+    args: list[str | Path] = [
+        os.environ.get('LIPO', 'lipo'),
+        '-create',
+        '-output',
+        outpath,
+    ]
+    args.extend(paths)
+    subprocess.check_call(args)
+    return outpath
+
+
+def all_equal(items: Iterable[Any]) -> bool:
+    it = iter(items)
+    first = next(it)
+    return all(i == first for i in it)

--- a/utils/write-universal-bdist.py
+++ b/utils/write-universal-bdist.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+#
+# Tools for building OpenSlide and its dependencies
+#
+# Copyright (c) 2023 Benjamin Gilbert
+# All rights reserved.
+#
+# This script is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License, version 2.1,
+# as published by the Free Software Foundation.
+#
+# This script is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this script. If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import annotations
+
+import argparse
+from contextlib import ExitStack
+from pathlib import Path
+import tempfile
+from typing import BinaryIO, cast
+
+from common.archive import (
+    DirMember,
+    FileMember,
+    SymlinkMember,
+    TarArchiveReader,
+    TarArchiveWriter,
+)
+from common.argparse import TypedArgs
+from common.macos import all_equal, merge_macho
+
+DSYM_ARCHES = {'aarch64', 'x86_64'}
+
+
+class Args(TypedArgs):
+    bdists: list[BinaryIO]
+    output: BinaryIO
+
+
+args = Args(
+    'write-universal-bdist', description='Write macOS universal bdist archive.'
+)
+args.add_arg(
+    '-o',
+    '--output',
+    type=argparse.FileType('wb'),
+    required=True,
+    help='output file',
+)
+args.add_arg(
+    'bdists',
+    metavar='bdist',
+    nargs='+',
+    type=argparse.FileType('rb'),
+    help='input file',
+)
+args.parse()
+
+with ExitStack() as stack:
+    tempdir = Path(
+        stack.enter_context(
+            tempfile.TemporaryDirectory(prefix='openslide-bin-')
+        )
+    )
+    readers = stack.enter_context(TarArchiveReader.group(args.bdists))
+    out = stack.enter_context(TarArchiveWriter(args.output))
+    for members in readers:
+        if all_equal(type(m) for m in members):
+            all_type: type | None = type(members[0])
+        else:
+            all_type = None
+        if not all_equal(members.relpaths):
+            # path mismatch, which we only allow for dSYM relocations.
+            # ensure we have a path component which is a dSYM arch
+            if not all(
+                DSYM_ARCHES.intersection(p.parts) for p in members.relpaths
+            ):
+                raise Exception(f'Path mismatch: {members.relpaths}')
+            if all_type in (DirMember, FileMember):
+                for member in members:
+                    out.add(member.with_base(out.base))
+            else:
+                raise Exception(
+                    'Unknown/mismatched types for relocations: '
+                    f'{members.relpaths}'
+                )
+        elif all_type is DirMember or (
+            all_type is SymlinkMember
+            and all_equal(cast(SymlinkMember, m).target for m in members)
+        ):
+            out.add(members[0].with_base(out.base))
+        elif all_type is FileMember:
+            if (
+                len(members.datas[0]) >= 4
+                and members.datas[0][0:4] == b'\xcf\xfa\xed\xfe'
+            ):
+                macho_path = merge_macho(
+                    [Path(cast(FileMember, m).fh.name) for m in members],
+                    tempdir,
+                )
+                out.add(
+                    FileMember(
+                        out.base / members[0].relpath,
+                        open(macho_path, 'rb'),
+                    )
+                )
+            elif members[0].path.suffix == '.jar':
+                # non-reproducible build; pick one
+                out.add(members[0].with_base(out.base))
+            elif all_equal(members.datas):
+                out.add(members[0].with_base(out.base))
+            else:
+                raise Exception(f'Contents mismatch: {members.relpaths}')
+        else:
+            raise Exception(f'Unknown/mismatched types: {members.relpaths}')


### PR DESCRIPTION
Apple clang supports building for multiple architectures at once, e.g. `-arch arm64 -arch x86_64`.  However, some projects make configuration decisions based on the Meson host CPU type, and thus need to build separately for arm64 and x86_64.  We'll handle this by configuring and building twice, and then combining the two bdist artifacts outside of Meson.

Add a tool that walks multiple bdist archives, runs `lipo` to combine Mach-O binaries, adds all architecture-specific relocation files, verifies that all other files are identical between builds, and produces a new tarball.  Filesystem metadata for duplicated items is taken from the first input specified on the command line.

Update the Direct workflow to emit Meson-produced bdist archives, including a universal archive on macOS.  Include both architectures in the latter's filename for clarity, since toolchain support for deprecated architectures historically hasn't lasted forever.