### PR TITLE
workflows: update actions/cache to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,10 +113,11 @@ jobs:
           path: overrides.tar
 
       - name: Cache sources
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: build-packagecache
           path: subprojects/packagecache
+          save-always: true
       - name: Build source tarball
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"

--- a/.github/workflows/direct.yml
+++ b/.github/workflows/direct.yml
@@ -20,10 +20,11 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@v4
       - name: Cache sources
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: direct-cache
           path: subprojects/packagecache
+          save-always: true
       - name: Build
         id: build
         run: |
@@ -61,10 +62,11 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@v4
       - name: Cache sources
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: direct-cache
           path: subprojects/packagecache
+          save-always: true
       - name: Build
         id: build
         run: |


### PR DESCRIPTION
Use the new `save-always` option to save source tarballs even after a CI failure.