### PR TITLE
pre-commit: enable flake8 plugins in yesqa

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,6 +38,7 @@ repos:
     rev: v1.5.0
     hooks:
       - id: yesqa
+        additional_dependencies: [flake8-bugbear, Flake8-pyproject]
 
   - repo: https://github.com/PyCQA/flake8
     rev: 6.1.0


### PR DESCRIPTION
Prevent yesqa from removing `noqa` markers needed for plugins.