### PR TITLE
templates: OpenSlide Python CI stopped hardcoding `BIN_RELEASE`

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -13,4 +13,3 @@
 - [ ] Update website: `_data/releases.yaml`, maybe `_includes/news.md`
 - [ ] Possibly send mail to -announce and -users
 - [ ] Possibly post to [forum.image.sc](https://forum.image.sc/c/announcements/10)
-- [ ] Update `BIN_RELEASE` in [OpenSlide Python CI](https://github.com/openslide/openslide-python/blob/main/.github/workflows/python.yml)


### PR DESCRIPTION
For https://github.com/openslide/openslide-python/pull/265.