### PR TITLE
builder: drop Java

### DIFF
--- a/builder/linux/Dockerfile
+++ b/builder/linux/Dockerfile
@@ -2,11 +2,11 @@
 FROM quay.io/almalinuxorg/almalinux:8
 # NOTE: try to keep the current container image compatible with the latest
 # stable source release, so people can conveniently build from the source zip
-RUN touch /etc/openslide-linux-builder-v1
+RUN touch /etc/openslide-linux-builder-v2
 RUN dnf -y upgrade && \
     dnf -y install 'dnf-command(config-manager)' epel-release && \
     dnf config-manager --set-enabled powertools && \
-    dnf -y install gcc-c++ git-core java-1.8.0-openjdk-devel nasm ninja-build \
-    patchelf python3.11-pip unzip && \
+    dnf -y install gcc-c++ git-core nasm ninja-build patchelf python3.11-pip \
+    unzip && \
     dnf clean all
 RUN pip3 install auditwheel meson tomli

--- a/builder/windows/Dockerfile
+++ b/builder/windows/Dockerfile
@@ -1,7 +1,7 @@
 FROM docker.io/gentoo/stage3:latest
 # NOTE: try to keep the current container image compatible with the latest
 # stable source release, so people can conveniently build from the source zip
-RUN touch /etc/openslide-winbuild-builder-v2
+RUN touch /etc/openslide-winbuild-builder-v3
 RUN echo 'FEATURES="-sandbox -usersandbox -ipc-sandbox -network-sandbox -pid-sandbox"' >> /etc/portage/make.conf
 COPY package.accept_keywords /etc/portage/package.accept_keywords/cross
 COPY package.use /etc/portage/package.use/cross
@@ -9,7 +9,7 @@ RUN mkdir -p /var/db/repos/crossdev/{profiles,metadata} && echo crossdev > /var/
 COPY repos.conf /etc/portage/repos.conf/crossdev.conf
 COPY --from=docker.io/gentoo/portage:latest /var/db/repos/gentoo /var/db/repos/gentoo
 RUN emerge app-arch/zip app-portage/gentoolkit dev-lang/nasm \
-    dev-java/openjdk-bin dev-util/glib-utils dev-vcs/git sys-devel/crossdev && \
+    dev-libs/glib dev-util/glib-utils dev-vcs/git sys-devel/crossdev && \
     rm /var/cache/distfiles/*
 RUN crossdev -t x86_64-w64-mingw32 && \
     rm /var/cache/distfiles/*

--- a/builder/windows/package.use
+++ b/builder/windows/package.use
@@ -1,4 +1,3 @@
-dev-java/openjdk-bin headless-awt
 dev-libs/glib -elf -mime
 dev-vcs/git -perl
 


### PR DESCRIPTION
Now that there's been an openslide-bin release without OpenSlide Java, drop Java from the builder containers and bump the API versions.

Followup to #241.