### PR TITLE
openslide-bin 4.0.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Notable Changes in openslide-bin
 
+## Version 4.0.0.3, 2024-05-04
+
+* Remove OpenSlide Java, which no longer has a platform-dependent component
+* Update SQLite
+
+
 ## Version 4.0.0.2, 2024-03-29
 
 * Add Linux and macOS builds

--- a/common/meson.py
+++ b/common/meson.py
@@ -34,7 +34,7 @@ from typing import Any
 # A.B.C = OpenSlide version
 # D = ordinal of the openslide-bin release with this A.B.C, starting from 1
 # Update the version when releasing openslide-bin.
-_PROJECT_VERSION = '4.0.0.2'
+_PROJECT_VERSION = '4.0.0.3'
 
 
 def meson_source_root() -> Path:


### PR DESCRIPTION
Omit the zstd update from the changelog, since it just upstreams a patch we were already carrying.