### PR TITLE
bintool: don't hardcode x86_64 for Linux builds

### DIFF
--- a/bintool
+++ b/bintool
@@ -152,7 +152,9 @@ class BuildParams:
                     self, 'windows', 'x64', cross=True
                 )
             elif has_api('linux', [1, 2]):
-                plat = MesonPlatform(self, 'linux', 'x86_64', cross=False)
+                plat = MesonPlatform(
+                    self, 'linux', platform.machine(), cross=False
+                )
             elif sys.platform == 'darwin':
                 # no container image to check for
                 plat = MacPlatform(self, ['arm64', 'x86_64'])


### PR DESCRIPTION
If we use `platform.machine()` to get the CPU architecture, bintool can build for Linux on any arch as long as a) it's running in a builder container for that arch, and b) a machine file exists.

Don't add any additional containers or machine files for now, since we can't efficiently run non-x86_64 builds in GitHub Actions.