### PR TITLE
workflows: switch from `macos-14` to `macos-latest`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -151,7 +151,7 @@ jobs:
     strategy:
       matrix:
         os: ${{ fromJson(needs.sdist.outputs.systems) }}
-    runs-on: ${{ matrix.os == 'macos' && 'macos-14' || 'ubuntu-latest' }}
+    runs-on: ${{ matrix.os == 'macos' && 'macos-latest' || 'ubuntu-latest' }}
     container: ${{ matrix.os == 'linux' && inputs.linux_builder_repo_and_digest || (matrix.os == 'windows' && inputs.windows_builder_repo_and_digest || null) }}
     steps:
       - name: Install dependencies (macOS)


### PR DESCRIPTION
The latter is now an alias for the former.  Switch back so we get future OS updates.