### PR TITLE
workflows: perform builder container builds on Ubuntu 24.04

### DIFF
--- a/.github/workflows/container-linux.yml
+++ b/.github/workflows/container-linux.yml
@@ -5,10 +5,10 @@ name: Container - Linux
 on:
   push:
     branches: [main]
-    paths: [builder/linux/*]
+    paths: [.github/workflows/container-linux.yml, builder/linux/*]
   pull_request:
     branches: [main]
-    paths: [builder/linux/*]
+    paths: [.github/workflows/container-linux.yml, builder/linux/*]
   schedule:
     - cron: "40 14 1 * *"
   workflow_dispatch:

--- a/.github/workflows/container-linux.yml
+++ b/.github/workflows/container-linux.yml
@@ -26,7 +26,7 @@ env:
 jobs:
   container:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/.github/workflows/container-windows.yml
+++ b/.github/workflows/container-windows.yml
@@ -5,10 +5,10 @@ name: Container - Windows
 on:
   push:
     branches: [main]
-    paths: [builder/windows/*]
+    paths: [.github/workflows/container-windows.yml, builder/windows/*]
   pull_request:
     branches: [main]
-    paths: [builder/windows/*]
+    paths: [.github/workflows/container-windows.yml, builder/windows/*]
   schedule:
     - cron: "40 14 1 * *"
   workflow_dispatch:

--- a/.github/workflows/container-windows.yml
+++ b/.github/workflows/container-windows.yml
@@ -26,7 +26,7 @@ env:
 jobs:
   container:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v4


### PR DESCRIPTION
The Windows container rebuild has started failing in CI:

    mkfifo: cannot set permissions of '/var/tmp/portage/sys-apps/config-site-0/temp/multijob.YksfGq': Operation not permitted
     * ERROR: sys-apps/config-site-0::gentoo failed:
     *   (no error message)

This doesn't happen when building locally on Fedora 40.  Updating the CI runner to Ubuntu 24.04 (and thus a newer Podman) fixes it, so do that.

Also rebuild builder containers when their rebuild workflows change.