### PR TITLE
builder/windows: explicitly install tomli

### DIFF
--- a/builder/windows/Dockerfile
+++ b/builder/windows/Dockerfile
@@ -8,8 +8,8 @@ COPY package.use /etc/portage/package.use/cross
 RUN mkdir -p /var/db/repos/crossdev/{profiles,metadata} && echo crossdev > /var/db/repos/crossdev/profiles/repo_name && echo 'masters = gentoo' > /var/db/repos/crossdev/metadata/layout.conf && chown -R portage:portage /var/db/repos/crossdev
 COPY repos.conf /etc/portage/repos.conf/crossdev.conf
 COPY --from=docker.io/gentoo/portage:latest /var/db/repos/gentoo /var/db/repos/gentoo
-RUN emerge app-arch/zip app-portage/gentoolkit dev-lang/nasm \
-    dev-libs/glib dev-util/glib-utils dev-vcs/git sys-devel/crossdev && \
+RUN emerge app-arch/zip app-portage/gentoolkit dev-lang/nasm dev-libs/glib \
+    dev-python/tomli dev-util/glib-utils dev-vcs/git sys-devel/crossdev && \
     rm /var/cache/distfiles/*
 RUN crossdev -t x86_64-w64-mingw32 && \
     rm /var/cache/distfiles/*


### PR DESCRIPTION
It's no longer being pulled in as a dependency.