### PR TITLE
builder: add new API versions for Meson 1.5.0+

### DIFF
--- a/builder/linux/Dockerfile
+++ b/builder/linux/Dockerfile
@@ -3,7 +3,7 @@ FROM quay.io/almalinuxorg/almalinux:8
 # NOTE: try to keep the current container image compatible with the latest
 # stable source release, so people can conveniently build from the source
 # tarball
-RUN touch /etc/openslide-linux-builder-v2
+RUN touch /etc/openslide-linux-builder-v{2,3}
 RUN dnf -y upgrade && \
     dnf -y install 'dnf-command(config-manager)' epel-release && \
     dnf config-manager --set-enabled powertools && \

--- a/builder/windows/Dockerfile
+++ b/builder/windows/Dockerfile
@@ -4,7 +4,7 @@ FROM docker.io/gentoo/stage3:latest
 # tarball
 RUN touch /etc/openslide-winbuild-builder-v3
 RUN echo 'FEATURES="-sandbox -usersandbox -ipc-sandbox -network-sandbox -pid-sandbox"' >> /etc/portage/make.conf
-COPY package.use /etc/portage/package.use/cross
+COPY package.use /etc/portage/package.use/openslide
 RUN mkdir -p /var/db/repos/crossdev/{profiles,metadata} && echo crossdev > /var/db/repos/crossdev/profiles/repo_name && echo 'masters = gentoo' > /var/db/repos/crossdev/metadata/layout.conf && chown -R portage:portage /var/db/repos/crossdev
 COPY repos.conf /etc/portage/repos.conf/crossdev.conf
 COPY --from=docker.io/gentoo/portage:latest /var/db/repos/gentoo /var/db/repos/gentoo

--- a/builder/windows/Dockerfile
+++ b/builder/windows/Dockerfile
@@ -2,7 +2,7 @@ FROM docker.io/gentoo/stage3:latest
 # NOTE: try to keep the current container image compatible with the latest
 # stable source release, so people can conveniently build from the source
 # tarball
-RUN touch /etc/openslide-winbuild-builder-v3
+RUN touch /etc/openslide-winbuild-builder-v{3,4}
 RUN echo 'FEATURES="-sandbox -usersandbox -ipc-sandbox -network-sandbox -pid-sandbox"' >> /etc/portage/make.conf
 COPY package.accept_keywords /etc/portage/package.accept_keywords/openslide
 COPY package.use /etc/portage/package.use/openslide

--- a/builder/windows/Dockerfile
+++ b/builder/windows/Dockerfile
@@ -4,10 +4,13 @@ FROM docker.io/gentoo/stage3:latest
 # tarball
 RUN touch /etc/openslide-winbuild-builder-v3
 RUN echo 'FEATURES="-sandbox -usersandbox -ipc-sandbox -network-sandbox -pid-sandbox"' >> /etc/portage/make.conf
+COPY package.accept_keywords /etc/portage/package.accept_keywords/openslide
 COPY package.use /etc/portage/package.use/openslide
 RUN mkdir -p /var/db/repos/crossdev/{profiles,metadata} && echo crossdev > /var/db/repos/crossdev/profiles/repo_name && echo 'masters = gentoo' > /var/db/repos/crossdev/metadata/layout.conf && chown -R portage:portage /var/db/repos/crossdev
 COPY repos.conf /etc/portage/repos.conf/crossdev.conf
 COPY --from=docker.io/gentoo/portage:latest /var/db/repos/gentoo /var/db/repos/gentoo
+RUN emerge -u dev-build/meson && \
+    rm /var/cache/distfiles/*
 RUN emerge app-portage/gentoolkit dev-lang/nasm dev-libs/glib \
     dev-python/tomli dev-util/glib-utils dev-vcs/git sys-devel/crossdev && \
     rm /var/cache/distfiles/*

--- a/builder/windows/package.accept_keywords
+++ b/builder/windows/package.accept_keywords
@@ -1,0 +1,1 @@
+dev-build/meson ~amd64


### PR DESCRIPTION
We're about to remove a bug workaround from `bintool`, and it needs to know that Meson is new enough.

Accept `~amd64` Meson in the Windows builder container so it gets new Meson releases quickly.