### PR TITLE
Use Anitya for update checking

### DIFF
--- a/.github/workflows/update-check.yml
+++ b/.github/workflows/update-check.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           python-version: 3.12
       - name: Install dependencies
-        run: pip install --user meson packaging requests
+        run: pip install --user meson requests
       - name: Check out repo
         uses: actions/checkout@v4
         with:

--- a/README.md
+++ b/README.md
@@ -89,8 +89,9 @@ To add a dependency to openslide-bin:
 1. Use `meson wrap install` to add the dependency's wrap file from wrapdb
    to the `subprojects` directory.
 2. Add the dependency to `_PROJECTS` in `common/software.py`.
-   - Test the `update_url` and `update_regex` by running `./bintool updates`.
-     A successful run will not produce an output line for the new dependency.
+   - Test update checking by running `./bintool updates`.  If this complains
+     that the project is missing from the Anitya database, ensure [Anitya][]
+     maps the project to Meson WrapDB.
 3. Modify `deps/meson.build` to invoke the build, in the correct order
    relative to the other dependencies.  Include any necessary build options,
    e.g. disable building command-line tools to reduce build time.
@@ -132,5 +133,6 @@ added to wrapdb before the first OpenSlide release that uses the library.
 Similarly, all `diff_files` directives in wrap files must have a comment
 linking to a wrapdb PR or upstream PR for the patch.
 
+[Anitya]: https://release-monitoring.org/
 [Meson]: https://mesonbuild.com/
 [wrapdb]: https://github.com/mesonbuild/wrapdb

--- a/bintool
+++ b/bintool
@@ -636,20 +636,13 @@ def do_clean(args: Args) -> None:
 
 
 def do_updates(args: Args) -> None:
-    def progress(s: str = '') -> None:
-        # if we're not in a pipeline, write progress to stderr
-        if sys.stdout.isatty():
-            log(f'{s:79}', end='\r', stderr=True)
-
     # reset overrides before reading package versions
     with BuildParams().lock():
         for proj in Project.get_all():
-            progress(f'Checking {proj.id}...')
             cur = proj.version.split('-')[0]
-            new = proj.get_upstream_version() or 'unknown'
+            new = proj.get_upstream_version()
             if cur != new:
                 print(f'{proj.id:15} {cur:>10}  => {new:>10}')
-        progress()
 
 
 def do_projects(args: Args) -> None:


### PR DESCRIPTION
Since there's already a centralized service that monitors project versions and has to track changes to project URLs etc., query that service rather than regexing web pages ourselves.

Drop progress reporting since we only need to make a couple HTTP requests.