### PR TITLE
workflows: drop `save-always` from `actions/cache` invocation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,7 +100,6 @@ jobs:
         with:
           key: build-packagecache
           path: subprojects/packagecache
-          save-always: true
       - name: Build source tarball
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"


### PR DESCRIPTION
The option never actually worked, and is being deprecated upstream.  We could implement it ourselves with separate `actions/cache/save` and `actions/cache/restore` invocations, but don't bother for now.