### PR TITLE
Disable glib debug infrastructure

### DIFF
--- a/deps/meson.build
+++ b/deps/meson.build
@@ -102,6 +102,7 @@ subproject(
     'introspection=disabled',
     'nls=disabled',
     'tests=false',
+    'glib_debug=disabled',
   ],
 )
 subproject(


### PR DESCRIPTION
It carries a performance hit, and upstream recommends disabling it in production builds.  Until now, glib has automatically disabled debug infra with our build settings, but glib 2.82+ will enable it by default.