### PR TITLE
Fix Windows exported symbol check on binutils 2.43; bump builder API version

### DIFF
--- a/artifacts/postprocess-binary.py
+++ b/artifacts/postprocess-binary.py
@@ -55,7 +55,9 @@ def library_symbols(file: Path) -> list[str]:
             if active:
                 if not line.strip():
                     return syms
-                syms.append(line.split()[2])
+                sym = line.split()[-1]
+                if sym != 'Name':
+                    syms.append(sym)
             elif 'Ordinal/Name Pointer' in line:
                 active = True
         raise Exception("Couldn't parse objdump output")

--- a/bintool
+++ b/bintool
@@ -50,7 +50,7 @@ from common.meson import (
 )
 from common.software import Project
 
-WINDOWS_API_VERS = (4,)
+WINDOWS_API_VERS = (4, 5)
 LINUX_API_VERS = (3,)
 # we have a higher minimum than the underlying meson.build
 MESON_MIN_VER = (1, 5, 0)

--- a/builder/windows/Dockerfile
+++ b/builder/windows/Dockerfile
@@ -2,7 +2,7 @@ FROM docker.io/gentoo/stage3:latest
 # NOTE: try to keep the current container image compatible with the latest
 # stable source release, so people can conveniently build from the source
 # tarball
-RUN touch /etc/openslide-winbuild-builder-v{3,4}
+RUN touch /etc/openslide-winbuild-builder-v5
 RUN echo 'FEATURES="-sandbox -usersandbox -ipc-sandbox -network-sandbox -pid-sandbox"' >> /etc/portage/make.conf
 COPY package.accept_keywords /etc/portage/package.accept_keywords/openslide
 COPY package.use /etc/portage/package.use/openslide


### PR DESCRIPTION
binutils 2.43 added some columns and a header row to the exported symbol list.  Update our check accordingly.  The new code works with older binutils as well.

We could pin older binutils in the Windows builder container, but that's probably more backward compatibility glue than we want to maintain here.  Bump the builder API version so older openslide-bin source releases will fail cleanly, and have bintool accept both API versions.