### PR TITLE
workflows: install python-packaging from PyPI on macOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -163,9 +163,9 @@ jobs:
               brew link --overwrite $formula
           done
           brew update
-          # python-packaging needed by glib
-          brew install meson python-packaging
-          python3 -m pip install --break-system-packages tomli
+          brew install meson
+          # packaging needed by glib
+          python3 -m pip install --break-system-packages packaging tomli
       - name: Download source tarball
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
Avoid Homebrew deprecation warning:

    python-packaging has been deprecated! It will be disabled on 2024-10-05.