### PR TITLE
workflows: update `peter-evans/create-pull-request` to v7

### DIFF
--- a/.github/workflows/update-check.yml
+++ b/.github/workflows/update-check.yml
@@ -50,7 +50,7 @@ jobs:
           modified=$(echo $modified | sed -e 's/ /, /g')
           echo "modified=$modified" >> $GITHUB_OUTPUT
       - name: Post updated wraps
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.OPENSLIDE_BOT_TOKEN }}
           author: "${{ env.GIT_NAME }} <${{ env.GIT_EMAIL }}>"
@@ -63,6 +63,7 @@ jobs:
           body: "<!-- topic=dependencies -->"
           push-to-fork: ${{ steps.user.outputs.username }}/${{ github.event.repository.name }}
           delete-branch: true
+          maintainer-can-modify: false
       - name: Check for stale dependencies
         run: |
           set -o pipefail


### PR DESCRIPTION
Forbid maintainers from modifying automatic PRs, since the next workflow run will overwrite their changes.