### PR TITLE
Add linux-aarch64 artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,22 +135,33 @@ jobs:
         shell: python
         run: |
           import json, os
-          sys_map = {
-              '${{ inputs.linux_builder_repo_and_digest }}': 'linux',
-              '${{ inputs.macos_enable && 'true' || '' }}': 'macos',
-              '${{ inputs.windows_builder_repo_and_digest }}': 'windows',
-          }
-          systems = json.dumps(sorted(v for k, v in sys_map.items() if k))
+          systems = []
+          if '${{ inputs.linux_builder_repo_and_digest }}':
+              for arch in 'aarch64', 'x86_64':
+                  systems.append({
+                      'os': 'linux',
+                      'arch': arch,
+                  })
+          if ${{ inputs.macos_enable && 1 || 0 }}:
+              systems.append({
+                  'os': 'macos',
+                  'arch': 'arm64-x86_64',
+              })
+          if '${{ inputs.windows_builder_repo_and_digest }}':
+              systems.append({
+                  'os': 'windows',
+                  'arch': 'x64',
+              })
           with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
-              fh.write(f'systems={systems}\n')
+              fh.write(f'systems={json.dumps(systems)}\n')
 
   bdist:
     name: Binaries
     needs: sdist
     strategy:
       matrix:
-        os: ${{ fromJson(needs.sdist.outputs.systems) }}
-    runs-on: ${{ matrix.os == 'macos' && 'macos-latest' || 'ubuntu-latest' }}
+        include: ${{ fromJson(needs.sdist.outputs.systems) }}
+    runs-on: ${{ matrix.os == 'macos' && 'macos-latest' || (matrix.os == 'linux' && matrix.arch == 'aarch64') && 'ubuntu-24.04-aarch64' || 'ubuntu-latest' }}
     container: ${{ matrix.os == 'linux' && inputs.linux_builder_repo_and_digest || (matrix.os == 'windows' && inputs.windows_builder_repo_and_digest || null) }}
     steps:
       - name: Install dependencies (macOS)

--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ SDK libraries on macOS, and glibc on Linux.
 ## Building
 
 For Windows and Linux, the build runs in a container image that includes the
-necessary tools.  To build for Windows, pull the container image on Linux or
-in Windows PowerShell with WSL 2 and use it to run a build:
+necessary tools.  To build for Windows on x64, pull the container image on
+Linux or in Windows PowerShell with WSL 2 and use it to run a build:
 
     docker run -ti --rm -v ${PWD}:/work -w /work \
         ghcr.io/openslide/winbuild-builder ./bintool bdist
 
-Similarly, to build for Linux:
+Similarly, to build for Linux on aarch64 or x86_64:
 
     docker run -ti --rm -v ${PWD}:/work -w /work \
         ghcr.io/openslide/linux-builder ./bintool bdist

--- a/machines/native-linux-aarch64.ini
+++ b/machines/native-linux-aarch64.ini
@@ -1,0 +1,12 @@
+[built-in options]
+prefix = '/'
+c_args = ['-O2', '-g', '-fpic', '-fstack-clash-protection', '-fexceptions', '-ftree-vectorize', '-fstack-protector-strong', '-D_FORTIFY_SOURCE=2']
+c_link_args = ['-Wl,-z,relro', '-Wl,-z,now', '-Wl,--exclude-libs,ALL']
+cpp_args = ['-O2', '-g', '-fpic', '-fstack-clash-protection', '-fexceptions', '-ftree-vectorize', '-fstack-protector-strong', '-D_FORTIFY_SOURCE=2']
+cpp_link_args = ['-Wl,-z,relro', '-Wl,-z,now', '-Wl,--exclude-libs,ALL']
+pkg_config_path = ''
+
+[properties]
+pkg_config_libdir = '/native/lib/pkgconfig'
+openslide_bin_platform = 'linux-aarch64'
+python_platform_tag = 'manylinux_2_28_aarch64'


### PR DESCRIPTION
For consistency, pass the CPU architecture to `bdist` workflow jobs for all OSes.