### PR TITLE
Mark Python wheel as containing type hints

### DIFF
--- a/artifacts/python/meson.build
+++ b/artifacts/python/meson.build
@@ -13,6 +13,7 @@ py_artifacts = [
     input : '__init__.in.py',
     output : '__init__.py',
   ),
+  files('py.typed'),
   libopenslide_postprocessed,
   licenses,
 ]

--- a/artifacts/python/pyproject.in.toml
+++ b/artifacts/python/pyproject.in.toml
@@ -25,6 +25,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering :: Bio-Informatics",
+    "Typing :: Typed",
 ]
 requires-python = ">= 3.8"
 


### PR DESCRIPTION
`__init__.py` has type hints, but type checkers will ignore these when checking OpenSlide Python unless we add `py.typed`.

Also add Trove classifier, by convention.