### PR TITLE
workflows: switch container build runners back to `ubuntu-latest`

### DIFF
--- a/.github/workflows/container-linux.yml
+++ b/.github/workflows/container-linux.yml
@@ -26,7 +26,7 @@ env:
 jobs:
   container:
     name: Build
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - name: Install dependencies
         run: |

--- a/.github/workflows/container-windows.yml
+++ b/.github/workflows/container-windows.yml
@@ -26,7 +26,7 @@ env:
 jobs:
   container:
     name: Build
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check out repository
         uses: actions/checkout@v4


### PR DESCRIPTION
It's now an alias for `ubuntu-24.04`, so we can stop hardcoding the OS version.