### PR TITLE
Version bumps for Python 3.13; fix a Python 3.11 incompatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -229,7 +229,7 @@ jobs:
       - name: Update Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.12
+          python-version: '3.13'
       - name: Download archives
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.13'
       - name: Run pre-commit hooks
         uses: pre-commit/action@v3.0.1
   setup:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.13'
       - name: Run pre-commit hooks
         uses: pre-commit/action@v3.0.1
   setup:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Update Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.12
+          python-version: '3.13'
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/update-check.yml
+++ b/.github/workflows/update-check.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Update Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.12
+          python-version: '3.13'
       - name: Install dependencies
         run: pip install --user meson requests
       - name: Check out repo

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.18.0
+    rev: v3.19.0
     hooks:
       - id: pyupgrade
         name: Modernize python code
@@ -48,7 +48,7 @@ repos:
         additional_dependencies: [flake8-bugbear, Flake8-pyproject]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.12.0
+    rev: v1.13.0
     hooks:
       - id: mypy
         name: Check Python types

--- a/artifacts/python/pyproject.in.toml
+++ b/artifacts/python/pyproject.in.toml
@@ -24,6 +24,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering :: Bio-Informatics",
     "Typing :: Typed",
 ]

--- a/common/software.py
+++ b/common/software.py
@@ -26,6 +26,7 @@ import configparser
 from dataclasses import dataclass
 from functools import cache, cached_property
 from itertools import count
+import os
 from pathlib import Path
 import shutil
 import subprocess
@@ -227,9 +228,9 @@ class Project(Software):
             return
         for subdir in self.remove_dirs:
             shutil.rmtree(projdir / subdir)
-        for dirpath, _, filenames in projdir.walk(on_error=walkerr):
+        for dirpath, _, filenames in os.walk(projdir, onerror=walkerr):
             for filename in filenames:
-                path = dirpath / filename
+                path = Path(dirpath) / filename
                 if path.relative_to(projdir).as_posix() in self.keep_files:
                     continue
                 if (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.black]
 line-length = 79
 skip-string-normalization = true
-target-version = ["py311", "py312"]
+target-version = ["py311", "py312", "py313"]
 
 # https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html#flake8
 # requires Flake8-pyproject

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,4 +16,5 @@ line_length = 79
 
 [tool.mypy]
 namespace_packages = false
+python_version = "3.11"
 strict = true


### PR DESCRIPTION
`Path.walk()` is not available in Python 3.11; use `os.walk()` instead.  CI didn't catch this because the sdist is built in the Windows builder, which has a newer Python, rather than the Linux builder, which has 3.11.