### PR TITLE
Update sqlite3

### DIFF
--- a/deps/meson.build
+++ b/deps/meson.build
@@ -61,7 +61,10 @@ if all_systems or system != 'darwin'
     'libxml2',
     default_options : ['iconv=disabled', 'python=false'],
   )
-  subproject('sqlite3')
+  subproject(
+    'sqlite3',
+    default_options : ['all-extensions=disabled'],
+  )
 endif
 
 if all_systems or system != 'linux'

--- a/subprojects/sqlite3.wrap
+++ b/subprojects/sqlite3.wrap
@@ -3,11 +3,11 @@ directory = sqlite-amalgamation-3470200
 source_url = https://www.sqlite.org/2024/sqlite-amalgamation-3470200.zip
 source_filename = sqlite-amalgamation-3470200.zip
 source_hash = aa73d8748095808471deaa8e6f34aa700e37f2f787f4425744f53fdd15a89c40
-patch_filename = sqlite3_3.47.2-1_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/sqlite3_3.47.2-1/get_patch
-patch_hash = 7dc75cd8d985f675d0b9970d555ea61a131da95c07bc537d8c660c8465750934
-source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/sqlite3_3.47.2-1/sqlite-amalgamation-3470200.zip
-wrapdb_version = 3.47.2-1
+patch_filename = sqlite3_3.47.2-2_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/sqlite3_3.47.2-2/get_patch
+patch_hash = 5d8848dbe93f9e9f7601e09691a996d602576d0f1e59ca9df9753ba461d0b19d
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/sqlite3_3.47.2-2/sqlite-amalgamation-3470200.zip
+wrapdb_version = 3.47.2-2
 
 [provide]
 sqlite3 = sqlite3_dep


### PR DESCRIPTION
The wrap now supports SQLite extensions.  We don't need them, and they impose a size cost, so keep them disabled.