### PR TITLE
meson: drop redundant `sort_files` format option

### DIFF
--- a/meson.format
+++ b/meson.format
@@ -1,5 +1,4 @@
 group_arg_value = true
 indent_by = '  '
 kwargs_force_multiline = true
-sort_files = true
 wide_colon = true


### PR DESCRIPTION
Notwithstanding the Meson docs, `sort_files` has always defaulted to `true`.