### PR TITLE
builder/linux: bump Python to 3.12

### DIFF
--- a/builder/linux/Dockerfile
+++ b/builder/linux/Dockerfile
@@ -3,11 +3,11 @@ FROM quay.io/almalinuxorg/almalinux:8
 # NOTE: try to keep the current container image compatible with the latest
 # stable source release, so people can conveniently build from the source
 # tarball
-RUN touch /etc/openslide-linux-builder-v{2,3}
+RUN touch /etc/openslide-linux-builder-v{2,3,4}
 RUN dnf -y upgrade && \
     dnf -y install 'dnf-command(config-manager)' epel-release && \
     dnf config-manager --set-enabled powertools && \
     dnf -y install gcc-c++ git-core nasm ninja-build patchelf \
-    python3.11-pip && \
+    python3.12-pip && \
     dnf clean all
 RUN pip3 install auditwheel meson tomli


### PR DESCRIPTION
Add API v4 so bintool can require the newer Python.