### PR TITLE
Bump minimum Python to 3.12

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
     hooks:
       - id: pyupgrade
         name: Modernize python code
-        args: ["--py311-plus"]
+        args: ["--py312-plus"]
 
   - repo: https://github.com/PyCQA/isort
     rev: 6.0.1

--- a/bintool
+++ b/bintool
@@ -51,7 +51,7 @@ from common.meson import (
 from common.software import Project
 
 WINDOWS_API_VERS = (4, 5)
-LINUX_API_VERS = (3,)
+LINUX_API_VERS = (4,)
 # we have a higher minimum than the underlying meson.build
 MESON_MIN_VER = (1, 5, 0)
 
@@ -494,7 +494,7 @@ class BDistSmokeTester(SmokeTester):
                 zip.extractall(dir)
         else:
             with tarfile.open(fileobj=self._fh) as tar:
-                tar.extraction_filter = getattr(tarfile, 'tar_filter', None)
+                tar.extraction_filter = tarfile.tar_filter
                 tar.extractall(dir)
 
     def _invoke(self, desc: str, dir: Path, cmd_prefix: list[str]) -> None:

--- a/common/archive.py
+++ b/common/archive.py
@@ -266,8 +266,7 @@ class TarArchiveReader(ArchiveReader):
     def __init__(self, fh: BinaryIO):
         super().__init__(Path(fh.name))
         self._tar = tarfile.open(fileobj=fh)
-        if hasattr(tarfile, 'data_filter'):
-            self._tar.extraction_filter = tarfile.data_filter
+        self._tar.extraction_filter = tarfile.data_filter
 
     def close(self) -> None:
         self._tar.close()

--- a/common/software.py
+++ b/common/software.py
@@ -26,7 +26,6 @@ import configparser
 from dataclasses import dataclass
 from functools import cache, cached_property
 from itertools import count
-import os
 from pathlib import Path
 import shutil
 import subprocess
@@ -228,9 +227,9 @@ class Project(Software):
             return
         for subdir in self.remove_dirs:
             shutil.rmtree(projdir / subdir)
-        for dirpath, _, filenames in os.walk(projdir, onerror=walkerr):
+        for dirpath, _, filenames in projdir.walk(on_error=walkerr):
             for filename in filenames:
-                path = Path(dirpath) / filename
+                path = dirpath / filename
                 if path.relative_to(projdir).as_posix() in self.keep_files:
                     continue
                 if (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.black]
 line-length = 79
 skip-string-normalization = true
-target-version = ["py311", "py312", "py313"]
+target-version = ["py312", "py313"]
 
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
 [tool.codespell]
@@ -22,5 +22,5 @@ line_length = 79
 
 [tool.mypy]
 namespace_packages = false
-python_version = "3.11"
+python_version = "3.12"
 strict = true


### PR DESCRIPTION
All v4 and v5 Windows builder images have 3.12, and we just added a v4 Linux image with 3.12.  For macOS we can reasonably assume 3.12 since it's been out for a while.