### PR TITLE
Drop Python wheel support for Python 3.8

### DIFF
--- a/artifacts/python/README.md
+++ b/artifacts/python/README.md
@@ -20,7 +20,7 @@ of OpenSlide.
 Install with `pip install openslide-bin`.  OpenSlide Python ≥ 1.4.0 will
 automatically find openslide-bin and use it.
 
-openslide-bin is available for Python 3.8+ on the following platforms:
+openslide-bin is available for Python 3.9+ on the following platforms:
 
 - Linux aarch64 and x86_64 with glibc 2.28+ (Debian, Fedora, RHEL 8+,
   Ubuntu, many others)
@@ -29,8 +29,7 @@ openslide-bin is available for Python 3.8+ on the following platforms:
 
 pip older than 20.3 cannot install openslide-bin, claiming that it `is not a
 supported wheel on this platform`.  On platforms with these versions of pip
-(RHEL 8 and Ubuntu 20.04), upgrade pip first with `pip install --upgrade
-pip`.
+(RHEL 8), upgrade pip first with `pip install --upgrade pip`.
 
 ## Using
 

--- a/artifacts/python/__init__.in.py
+++ b/artifacts/python/__init__.in.py
@@ -30,13 +30,8 @@ def _load_openslide() -> CDLL:
         name = 'libopenslide.1.dylib'
     else:
         name = 'libopenslide.so.1'
-    try:
-        # Python >= 3.9
-        with res.as_file(res.files(__name__).joinpath(name)) as path:
-            return cdll.LoadLibrary(path.as_posix())
-    except AttributeError:
-        with res.path(__name__, name) as path:
-            return cdll.LoadLibrary(path.as_posix())
+    with res.as_file(res.files(__name__).joinpath(name)) as path:
+        return cdll.LoadLibrary(path.as_posix())
 
 
 libopenslide1 = _load_openslide()

--- a/artifacts/python/pyproject.in.toml
+++ b/artifacts/python/pyproject.in.toml
@@ -19,7 +19,6 @@ classifiers = [
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -28,7 +27,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Bio-Informatics",
     "Typing :: Typed",
 ]
-requires-python = ">= 3.8"
+requires-python = ">= 3.9"
 
 [project.urls]
 Homepage = "https://openslide.org/"


### PR DESCRIPTION
Python 3.8 is EOL.  Ubuntu 20.04 is the last officially-supported distro that uses it, and Ubuntu 20.04 will exit standard security maintenance on May 31.