### PR TITLE
Drop tomli dependency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -176,8 +176,8 @@ jobs:
           done
           brew update
           brew install meson
-          # packaging needed by glib
-          python3 -m pip install --break-system-packages packaging tomli
+          # needed by glib
+          python3 -m pip install --break-system-packages packaging
       - name: Download source tarball
         uses: actions/download-artifact@v4
         with:

--- a/bintool
+++ b/bintool
@@ -50,8 +50,8 @@ from common.meson import (
 )
 from common.software import Project
 
-WINDOWS_API_VERS = (4, 5)
-LINUX_API_VERS = (4,)
+WINDOWS_API_VERS = (4, 5, 6)
+LINUX_API_VERS = (4, 5)
 # we have a higher minimum than the underlying meson.build
 MESON_MIN_VER = (1, 5, 0)
 

--- a/common/python.py
+++ b/common/python.py
@@ -20,14 +20,13 @@
 from __future__ import annotations
 
 from email.message import Message
+import tomllib
 
 from .meson import meson_source_root
 
 
 def pyproject_to_message(pyproject: str) -> Message:
-    import tomli
-
-    meta = tomli.loads(pyproject)
+    meta = tomllib.loads(pyproject)
     out = Message()
     out['Metadata-Version'] = '2.3'
     for k, v in meta['project'].items():


### PR DESCRIPTION
We now require Python 3.12+ and the stdlib can parse TOML since 3.11.

Declare support for new builder APIs (Windows 6, Linux 5) without tomli so we can drop it after the next openslide-bin release.