### PR TITLE
builder: drop tomli, bump to new API versions

### DIFF
--- a/builder/linux/Dockerfile
+++ b/builder/linux/Dockerfile
@@ -3,11 +3,11 @@ FROM quay.io/almalinuxorg/almalinux:8
 # NOTE: try to keep the current container image compatible with the latest
 # stable source release, so people can conveniently build from the source
 # tarball
-RUN touch /etc/openslide-linux-builder-v{2,3,4}
+RUN touch /etc/openslide-linux-builder-v5
 RUN dnf -y upgrade && \
     dnf -y install 'dnf-command(config-manager)' epel-release && \
     dnf config-manager --set-enabled powertools && \
     dnf -y install gcc-c++ git-core nasm ninja-build patchelf \
     python3.12-pip && \
     dnf clean all
-RUN pip3 install auditwheel meson tomli
+RUN pip3 install auditwheel meson

--- a/builder/windows/Dockerfile
+++ b/builder/windows/Dockerfile
@@ -2,7 +2,7 @@ FROM docker.io/gentoo/stage3:latest
 # NOTE: try to keep the current container image compatible with the latest
 # stable source release, so people can conveniently build from the source
 # tarball
-RUN touch /etc/openslide-winbuild-builder-v5
+RUN touch /etc/openslide-winbuild-builder-v6
 RUN echo 'FEATURES="-sandbox -usersandbox -ipc-sandbox -network-sandbox -pid-sandbox"' >> /etc/portage/make.conf
 COPY package.accept_keywords /etc/portage/package.accept_keywords/openslide
 COPY package.use /etc/portage/package.use/openslide
@@ -12,7 +12,7 @@ COPY --from=docker.io/gentoo/portage:latest /var/db/repos/gentoo /var/db/repos/g
 RUN emerge -u dev-build/meson && \
     rm -f /var/cache/distfiles/*
 RUN emerge app-portage/gentoolkit dev-lang/nasm dev-libs/glib \
-    dev-python/tomli dev-util/glib-utils dev-vcs/git sys-devel/crossdev && \
+    dev-util/glib-utils dev-vcs/git sys-devel/crossdev && \
     rm /var/cache/distfiles/*
 RUN crossdev -t x86_64-w64-mingw32 && \
     rm /var/cache/distfiles/*


### PR DESCRIPTION
openslide-bin 4.0.0.8 stopped requiring tomli.