### PR TITLE
Avoid line folding in Python core metadata, fixing PyPI upload failure

### DIFF
--- a/common/python.py
+++ b/common/python.py
@@ -20,6 +20,7 @@
 from __future__ import annotations
 
 from email.message import Message
+from email.policy import Compat32
 import tomllib
 
 from .meson import meson_source_root
@@ -27,7 +28,7 @@ from .meson import meson_source_root
 
 def pyproject_to_message(pyproject: str) -> Message:
     meta = tomllib.loads(pyproject)
-    out = Message()
+    out = Message(policy=Compat32(max_line_length=None))
     out['Metadata-Version'] = '2.3'
     for k, v in meta['project'].items():
         k = k.lower()


### PR DESCRIPTION
Serialized Python core metadata must be parsable by `email.parser` with the `compat32` policy, and that configuration fails to remove the newline from the middle of folded headers.  The LGPLv2 Trove classifier triggers this case, and PyPI now has validation that rejects it as an invalid classifier.

Avoid folding by configuring `Message` to produce unlimited line lengths.