### PR TITLE
workflows: include hash of wrap files in `packagecache` cache key

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,10 +95,19 @@ jobs:
           name: build-overrides
           path: overrides.tar
 
+      - name: Calculate cache key
+        id: cache-key
+        run: |
+          # glob results are sorted
+          sha256=$(cat subprojects/*.wrap | sha256sum - | cut -c1-20)
+          echo "sha256=${sha256}" >> $GITHUB_OUTPUT
+          # use a fresh cache every year to flush out old sources
+          echo "year=$(date +%Y)" >> $GITHUB_OUTPUT
       - name: Cache sources
         uses: actions/cache@v4
         with:
-          key: build-packagecache
+          key: build-packagecache-${{ steps.cache-key.outputs.year }}-${{ steps.cache-key.outputs.sha256 }}
+          restore-keys: build-packagecache-${{ steps.cache-key.outputs.year }}-
           path: subprojects/packagecache
       - name: Build source tarball
         run: |


### PR DESCRIPTION
Caches are immutable and GitHub continues reusing them indefinitely as long as they're accessed once a week.  As a result, we're redownloading newer upstream sources on every build.  Include a truncated hash of the wrap files in the cache key, creating a new cache (after restoring from an existing one) whenever a wrap is changed.

The cache will accumulate old tarballs over time.  Clear these out once per year by switching to a fresh cache without restoring an old one.