### PR TITLE
workflows: install nasm on macOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -184,7 +184,7 @@ jobs:
               brew link --overwrite $formula
           done
           brew update
-          brew install meson
+          brew install meson nasm
           # packaging needed by glib
           python3 -m pip install --break-system-packages license-expression \
               packaging


### PR DESCRIPTION
libjpeg-turbo needs it for SIMD support on x86_64.  It turns out we've never had that enabled.