### PR TITLE
Set macOS `LC_BUILD_VERSION` in nasm-assembled objects

### DIFF
--- a/machines/cross-macos-x86_64.ini
+++ b/machines/cross-macos-x86_64.ini
@@ -6,6 +6,7 @@ cpp_args = ['-O2', '-g', '-fstack-protector-strong', '--target=x86_64-apple-maco
 cpp_link_args = ['--target=x86_64-apple-macosx11', '-Wl,-dead_strip', '-Wl,-exported_symbol,_openslide_*']
 objc_args = ['-O2', '-g', '-fstack-protector-strong', '--target=x86_64-apple-macosx11']
 objc_link_args = ['--target=x86_64-apple-macosx11', '-Wl,-dead_strip', '-Wl,-exported_symbol,_openslide_*']
+nasm_args = ['-f', 'macho64', '--pragma', 'macho build_version macos,11,0']
 pkg_config_path = ''
 
 [properties]


### PR DESCRIPTION
Avoid link warnings with ld-prime:

    ld: warning: no platform load command found in '[...]/work/bdist-macos-x86_64/subprojects/libjpeg-turbo-3.2.0/src/libjpeg.a[2](x86_64_jccolor-avx2.asm.o)', assuming: macOS

On Meson 1.12 these are fatal with `werror=true`.